### PR TITLE
Add torch.no_grad() to predict step

### DIFF
--- a/uq_method_box/uq_methods/base.py
+++ b/uq_method_box/uq_methods/base.py
@@ -165,7 +165,8 @@ class BaseModel(LightningModule):
         Args:
             X: prediction batch of shape [batch_size x input_dims]
         """
-        out = self.forward(X)
+        with torch.no_grad():
+            out = self.forward(X)
         return {
             "mean": self.extract_mean_output(out).squeeze(-1).detach().cpu().numpy()
         }
@@ -274,7 +275,8 @@ class EnsembleModel(LightningModule):
         Returns:
             mean and standard deviation of MC predictions
         """
-        preds = self.generate_ensemble_predictions(X)
+        with torch.no_grad():
+            preds = self.generate_ensemble_predictions(X)
 
         mean_samples = preds[:, 0, :].detach().cpu().numpy()
 

--- a/uq_method_box/uq_methods/cqr_model.py
+++ b/uq_method_box/uq_methods/cqr_model.py
@@ -4,6 +4,7 @@ import os
 from typing import Any, Dict, List, Tuple
 
 import numpy as np
+import torch
 from lightning import LightningModule
 from torch import Tensor
 from torch.utils.data import DataLoader
@@ -148,7 +149,9 @@ class CQR(LightningModule):
         """
         if not self.cqr_fitted:
             self.on_test_start()
-        model_preds: Dict[str, np.ndarray] = self.score_model.predict_step(X)
+
+        with torch.no_grad():
+            model_preds: Dict[str, np.ndarray] = self.score_model.predict_step(X)
         cqr_sets = np.stack(
             [
                 model_preds["lower_quant"] - self.q_hat,

--- a/uq_method_box/uq_methods/deterministic_gaussian.py
+++ b/uq_method_box/uq_methods/deterministic_gaussian.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Union
 
 import numpy as np
+import torch
 import torch.nn as nn
 from torch import Tensor
 
@@ -52,7 +53,8 @@ class DeterministicGaussianModel(BaseModel):
         Args:
             X: prediction batch of shape [batch_size x input_dims]
         """
-        preds = self.model(X)
+        with torch.no_grad():
+            preds = self.model(X)
         mean = preds[:, 0]
         std = preds[:, 1]
         quantiles = compute_quantiles_from_std(mean, std, self.quantiles)

--- a/uq_method_box/uq_methods/mc_dropout_model.py
+++ b/uq_method_box/uq_methods/mc_dropout_model.py
@@ -75,11 +75,12 @@ class MCDropoutModel(BaseModel):
             mean and standard deviation of MC predictions
         """
         self.model.train()  # activate dropout during prediction
-        preds = (
-            torch.stack([self.model(X) for _ in range(self.num_mc_samples)], dim=-1)
-            .detach()
-            .numpy()
-        )  # shape [num_samples, batch_size, num_outputs]
+        with torch.no_grad():
+            preds = (
+                torch.stack([self.model(X) for _ in range(self.num_mc_samples)], dim=-1)
+                .detach()
+                .numpy()
+            )  # shape [num_samples, batch_size, num_outputs]
 
         mean_samples = preds[:, 0, :]
 

--- a/uq_method_box/uq_methods/quantile_regression_model.py
+++ b/uq_method_box/uq_methods/quantile_regression_model.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Union
 
 import numpy as np
+import torch
 import torch.nn as nn
 from torch import Tensor
 
@@ -51,7 +52,8 @@ class QuantileRegressionModel(BaseModel):
         Returns:
             predicted uncertainties
         """
-        out = self.model(X).detach().numpy()  # [batch_size, len(self.quantiles)]
+        with torch.no_grad():
+            out = self.model(X).numpy()  # [batch_size, len(self.quantiles)]
         median = out[:, self.median_index]
         mean, std = compute_sample_mean_std_from_quantile(out, self.hparams.quantiles)
 


### PR DESCRIPTION
This PR adds the context manager `with torch.no_grad()` to the predict step to make it explicit and useable for toy regression examples, where you don't use the lightning trainer.