### PR TITLE
Add functionality that saves regression predictions to csv

### DIFF
--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -87,8 +87,8 @@ class DeterministicModel(BaseModule):
         """Set up task specific attributes."""
         raise NotImplementedError
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract mean output from model output.
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation.
 
         Args:
             out: output from the model
@@ -125,7 +125,9 @@ class DeterministicModel(BaseModule):
 
         self.log("train_loss", loss)  # logging to Logger
         if batch[self.input_key].shape[0] > 1:
-            self.train_metrics(self.extract_mean_output(out), batch[self.target_key])
+            self.train_metrics(
+                self.adapt_output_for_metrics(out), batch[self.target_key]
+            )
 
         return loss
 
@@ -151,7 +153,7 @@ class DeterministicModel(BaseModule):
 
         self.log("val_loss", loss)  # logging to Logger
         if batch[self.input_key].shape[0] > 1:
-            self.val_metrics(self.extract_mean_output(out), batch[self.target_key])
+            self.val_metrics(self.adapt_output_for_metrics(out), batch[self.target_key])
 
         return loss
 
@@ -204,7 +206,7 @@ class DeterministicModel(BaseModule):
         """
         with torch.no_grad():
             out = self.forward(X)
-        return {"pred": self.extract_mean_output(out)}
+        return {"pred": self.adapt_output_for_metrics(out)}
 
     def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.
@@ -279,8 +281,8 @@ class DeterministicClassification(DeterministicModel):
         self.task = task
         super().__init__(model, loss_fn, optimizer, lr_scheduler)
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract mean output from model output.
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation.
 
         Args:
             out: output from the model

--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -3,6 +3,7 @@
 
 """Base Model for UQ methods."""
 
+import os
 from typing import Any, Optional, Union
 
 import torch
@@ -16,6 +17,7 @@ from .utils import (
     _get_num_outputs,
     default_classification_metrics,
     default_regression_metrics,
+    save_regression_predictions,
 )
 
 
@@ -232,22 +234,25 @@ class DeterministicRegression(DeterministicModel):
         self.val_metrics = default_regression_metrics("val")
         self.test_metrics = default_regression_metrics("test")
 
-    # def on_test_batch_end(
-    #     self,
-    #     outputs: dict[str, Tensor],
-    #     batch: Any,
-    #     batch_idx: int,
-    #     dataloader_idx=0,
-    # ):
-    #     """Test batch end save predictions."""
-    #     if self.save_dir:
-    #         save_predictions_to_csv(
-    #             outputs, os.path.join(self.save_dir, self.pred_file_name)
-    # )
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )
 
 
 class DeterministicClassification(DeterministicModel):
     """Deterministic Base Trainer for classification as LightningModule."""
+
+    pred_file_name = "preds.csv"
 
     valid_tasks = ["binary", "multiclass", "multilable"]
 

--- a/lightning_uq_box/uq_methods/bnn_lv_vi.py
+++ b/lightning_uq_box/uq_methods/bnn_lv_vi.py
@@ -4,6 +4,7 @@
 """Bayesian Neural Networks with Variational Inference and Latent Variables."""  # noqa: E501
 
 import math
+import os
 from typing import Any, Optional, Tuple, Union
 
 import einops
@@ -25,6 +26,7 @@ from lightning_uq_box.uq_methods.utils import (
     _get_input_layer_name_and_module,
     _get_output_layer_name_and_module,
     default_regression_metrics,
+    save_regression_predictions,
 )
 
 from .bnn_vi import BNN_VI_Base
@@ -474,11 +476,28 @@ class BNN_LV_VI_Regression(BNN_LV_VI_Base):
 
     nll_loss = nn.GaussianNLLLoss(reduction="none", full=True)
 
+    pred_file_name = "preds.csv"
+
     def setup_task(self) -> None:
         """Set up task."""
         self.train_metrics = default_regression_metrics("train")
         self.val_metrics = default_regression_metrics("val")
         self.test_metrics = default_regression_metrics("test")
+
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        outputs = {k: v for k, v in outputs.items() if len(v.squeeze().shape) == 1}
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )
 
 
 class BNN_LV_VI_Batched_Base(BNN_LV_VI_Base):
@@ -786,8 +805,25 @@ class BNN_LV_VI_Batched_Regression(BNN_LV_VI_Batched_Base):
 
     nll_loss = nn.GaussianNLLLoss(reduction="none", full=True)
 
+    pred_file_name = "preds.csv"
+
     def setup_task(self) -> None:
         """Set up task."""
         self.train_metrics = default_regression_metrics("train")
         self.val_metrics = default_regression_metrics("val")
         self.test_metrics = default_regression_metrics("test")
+
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        outputs = {k: v for k, v in outputs.items() if len(v.squeeze().shape) == 1}
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )

--- a/lightning_uq_box/uq_methods/bnn_vi_elbo.py
+++ b/lightning_uq_box/uq_methods/bnn_vi_elbo.py
@@ -3,6 +3,7 @@
 
 """Bayesian Neural Networks with Variational Inference."""
 
+import os
 from typing import Any, Optional, Union
 
 import torch
@@ -25,6 +26,7 @@ from .utils import (
     process_classification_prediction,
     process_regression_prediction,
     process_segmentation_prediction,
+    save_regression_predictions,
 )
 
 
@@ -285,6 +287,8 @@ class BNN_VI_ELBO_Regression(BNN_VI_ELBO_Base):
     * https://arxiv.org/abs/1505.05424
     """
 
+    pred_file_name = "preds.csv"
+
     def __init__(
         self,
         model: nn.Module,
@@ -399,6 +403,21 @@ class BNN_VI_ELBO_Regression(BNN_VI_ELBO_Base):
 
         return process_regression_prediction(preds)
 
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        outputs = {k: v for k, v in outputs.items() if len(v.squeeze().shape) == 1}
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )
+
 
 class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
     """Bayes By Backprop Model with Variational Inference (VI) for Classification.
@@ -408,6 +427,7 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
     * https://arxiv.org/abs/1505.05424
     """
 
+    pred_file_name = "preds.csv"
     valid_tasks = ["binary", "multiclass", "multilable"]
 
     def __init__(

--- a/lightning_uq_box/uq_methods/bnn_vi_elbo.py
+++ b/lightning_uq_box/uq_methods/bnn_vi_elbo.py
@@ -199,7 +199,7 @@ class BNN_VI_ELBO_Base(DeterministicModel):
             # mean prediction
             pred = self.forward(X)
             pred_losses[i] = self.compute_task_loss(pred, y)
-            model_preds.append(self.extract_mean_output(pred).detach())
+            model_preds.append(self.adapt_output_for_metrics(pred).detach())
 
         mean_pred = torch.stack(model_preds, dim=-1).mean(-1)
         # dimension [batch_size]
@@ -380,7 +380,7 @@ class BNN_VI_ELBO_Regression(BNN_VI_ELBO_Base):
             self.criterion, nn.MSELoss
         ):
             # compute mse loss with output noise scale, is like mse
-            loss = torch.nn.functional.mse_loss(self.extract_mean_output(pred), y)
+            loss = torch.nn.functional.mse_loss(self.adapt_output_for_metrics(pred), y)
         else:
             # after burnin compute nll with log_sigma
             loss = self.criterion(pred, y)
@@ -529,8 +529,8 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
         """
         return self.criterion(pred, y)
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract mean output from model output."""
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation."""
         return out
 
     def predict_step(

--- a/lightning_uq_box/uq_methods/conformal_qr.py
+++ b/lightning_uq_box/uq_methods/conformal_qr.py
@@ -4,6 +4,7 @@
 """conformalized Quantile Regression Model."""
 
 import math
+import os
 from typing import Dict, Union
 
 import torch
@@ -13,6 +14,7 @@ from lightning.pytorch.utilities.types import OptimizerLRScheduler
 from torch import Tensor
 
 from .base import PosthocBase
+from .utils import save_regression_predictions
 
 
 def compute_q_hat_with_cqr(
@@ -55,6 +57,8 @@ class ConformalQR(PosthocBase):
 
     * https://papers.nips.cc/paper_files/paper/2019/hash/5103c3584b063c431bd1268e9b5e76fb-Abstract.html # noqa: E501
     """
+
+    pred_file_name = "preds.csv"
 
     def __init__(
         self,
@@ -166,3 +170,17 @@ class ConformalQR(PosthocBase):
     def configure_optimizers(self) -> OptimizerLRScheduler:
         """No optimizer needed for Conformal QR."""
         pass
+
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )

--- a/lightning_uq_box/uq_methods/deep_evidential_regression.py
+++ b/lightning_uq_box/uq_methods/deep_evidential_regression.py
@@ -3,6 +3,7 @@
 
 """Deep Evidential Regression."""
 
+import os
 
 import numpy as np
 import torch
@@ -12,7 +13,11 @@ from torch import Tensor
 
 from .base import DeterministicModel
 from .loss_functions import DERLoss
-from .utils import _get_num_outputs, default_regression_metrics
+from .utils import (
+    _get_num_outputs,
+    default_regression_metrics,
+    save_regression_predictions,
+)
 
 
 class DERLayer(nn.Module):
@@ -58,6 +63,8 @@ class DER(DeterministicModel):
 
     * https://arxiv.org/abs/2205.10060
     """
+
+    pred_file_name = "preds.csv"
 
     def __init__(
         self,
@@ -169,3 +176,17 @@ class DER(DeterministicModel):
             Epistemic Uncertainty
         """
         return np.reciprocal(np.sqrt(nu))
+
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )

--- a/lightning_uq_box/uq_methods/deep_evidential_regression.py
+++ b/lightning_uq_box/uq_methods/deep_evidential_regression.py
@@ -136,8 +136,8 @@ class DER(DeterministicModel):
             "out": pred,
         }
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract the mean output from 4D model prediction.
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation.
 
         Args:
             out: output from :meth:`self.forward` [batch_size x 4]

--- a/lightning_uq_box/uq_methods/deep_kernel_learning.py
+++ b/lightning_uq_box/uq_methods/deep_kernel_learning.py
@@ -456,8 +456,8 @@ class DKLClassification(DKLBase):
             "test", self.task, self.num_classes
         )
 
-    def _extract_mean_output(self, output: MultivariateNormal) -> Tensor:
-        """Extract the mean output from the GP."""
+    def _adapt_output_for_metrics(self, output: MultivariateNormal) -> Tensor:
+        """Adapt model output to be compatible for metric computation.."""
         return output.mean
 
     def _build_model(self) -> None:

--- a/lightning_uq_box/uq_methods/laplace_model.py
+++ b/lightning_uq_box/uq_methods/laplace_model.py
@@ -3,6 +3,7 @@
 
 """Laplace Approximation model."""
 
+import os
 from typing import Any
 
 import numpy as np
@@ -18,6 +19,7 @@ from .utils import (
     _get_num_outputs,
     default_classification_metrics,
     default_regression_metrics,
+    save_regression_predictions,
 )
 
 # TODO check whether Laplace fitting procedure can be implemented as working
@@ -50,6 +52,8 @@ def tune_prior_precision(
 
 class LaplaceBase(BaseModule):
     """Laplace Approximation method for regression."""
+
+    pred_file_name = "preds.csv"
 
     def __init__(
         self,
@@ -272,6 +276,20 @@ class LaplaceRegression(LaplaceBase):
             "epistemic_uct": laplace_epistemic,
             "aleatoric_uct": laplace_aleatoric,
         }
+
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )
 
 
 class LaplaceClassification(LaplaceBase):

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -3,6 +3,8 @@
 
 """Mc-Dropout module."""
 
+import os
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -18,6 +20,7 @@ from .utils import (
     process_classification_prediction,
     process_regression_prediction,
     process_segmentation_prediction,
+    save_regression_predictions,
 )
 
 
@@ -118,6 +121,8 @@ class MCDropoutRegression(MCDropoutBase):
     * https://proceedings.mlr.press/v48/gal16.html
     """
 
+    pred_file_name = "preds.csv"
+
     def __init__(
         self,
         model: nn.Module,
@@ -202,6 +207,20 @@ class MCDropoutRegression(MCDropoutBase):
 
         return process_regression_prediction(preds)
 
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )
+
 
 class MCDropoutClassification(MCDropoutBase):
     """MC-Dropout Model for Classification.
@@ -211,6 +230,7 @@ class MCDropoutClassification(MCDropoutBase):
     * https://proceedings.mlr.press/v48/gal16.html
     """
 
+    pred_file_name = "preds.csv"
     valid_tasks = ["binary", "multiclass", "multilable"]
 
     def __init__(

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -93,7 +93,7 @@ class MCDropoutBase(DeterministicModel):
         loss = self.loss_fn(out, batch[self.target_key])
 
         self.log("train_loss", loss)  # logging to Logger
-        self.train_metrics(self.extract_mean_output(out), batch[self.target_key])
+        self.train_metrics(self.adapt_output_for_metrics(out), batch[self.target_key])
 
         return loss
 
@@ -158,8 +158,8 @@ class MCDropoutRegression(MCDropoutBase):
         self.val_metrics = default_regression_metrics("val")
         self.test_metrics = default_regression_metrics("test")
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract mean output from model."""
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation.."""
         assert out.shape[-1] <= 2, "Ony support single mean or Gaussian output."
         return out[:, 0:1]
 
@@ -178,13 +178,13 @@ class MCDropoutRegression(MCDropoutBase):
 
         if self.current_epoch < self.hparams.burnin_epochs:
             loss = nn.functional.mse_loss(
-                self.extract_mean_output(out), batch[self.target_key]
+                self.adapt_output_for_metrics(out), batch[self.target_key]
             )
         else:
             loss = self.loss_fn(out, batch[self.target_key])
 
         self.log("train_loss", loss)  # logging to Logger
-        self.train_metrics(self.extract_mean_output(out), batch[self.target_key])
+        self.train_metrics(self.adapt_output_for_metrics(out), batch[self.target_key])
 
         return loss
 
@@ -277,7 +277,7 @@ class MCDropoutClassification(MCDropoutBase):
             "test", self.task, self.num_classes
         )
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
         """Extract mean output from model."""
         return out
 

--- a/lightning_uq_box/uq_methods/mean_variance_estimation.py
+++ b/lightning_uq_box/uq_methods/mean_variance_estimation.py
@@ -64,13 +64,13 @@ class MVEBase(DeterministicModel):
 
         if self.current_epoch < self.hparams.burnin_epochs:
             loss = nn.functional.mse_loss(
-                self.extract_mean_output(out), batch[self.target_key]
+                self.adapt_output_for_metrics(out), batch[self.target_key]
             )
         else:
             loss = self.loss_fn(out, batch[self.target_key])
 
         self.log("train_loss", loss)  # logging to Logger
-        self.train_metrics(self.extract_mean_output(out), batch[self.target_key])
+        self.train_metrics(self.adapt_output_for_metrics(out), batch[self.target_key])
 
         return loss
 
@@ -106,8 +106,8 @@ class MVERegression(MVEBase):
             ignore=["model", "loss_fn", "optimizer", "lr_scheduler"]
         )
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract mean output from model."""
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation."""
         assert out.shape[-1] <= 2, "Gaussian output."
         return out[:, 0:1]
 

--- a/lightning_uq_box/uq_methods/quantile_regression.py
+++ b/lightning_uq_box/uq_methods/quantile_regression.py
@@ -99,8 +99,8 @@ class QuantileRegression(QuantileRegressionBase):
             ignore=["model", "loss_fn", "optimizer", "lr_scheduler"]
         )
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract the mean/median prediction from quantile regression model.
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation.
 
         Args:
             out: output from :meth:`self.forward` [batch_size x num_outputs]
@@ -125,7 +125,7 @@ class QuantileRegression(QuantileRegressionBase):
             out = self.model(X)  # [batch_size, len(self.quantiles)]
             np_out = out.cpu().numpy()
 
-        median = self.extract_mean_output(out)
+        median = self.adapt_output_for_metrics(out)
         mean, std = compute_sample_mean_std_from_quantile(
             np_out, self.hparams.quantiles
         )

--- a/lightning_uq_box/uq_methods/sgld.py
+++ b/lightning_uq_box/uq_methods/sgld.py
@@ -202,8 +202,8 @@ class SGLDRegression(SGLDBase):
         self.val_metrics = default_regression_metrics("val")
         self.test_metrics = default_regression_metrics("test")
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract the mean output from model prediction.
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation.
 
         Args:
             out: output from :meth:`self.forward` [batch_size x (mu, sigma)]
@@ -234,7 +234,7 @@ class SGLDRegression(SGLDBase):
             """Closure function for optimizer."""
             sgld_opt.zero_grad()
             if self.current_epoch < self.hparams.burnin_epochs:
-                loss = nn.functional.mse_loss(self.extract_mean_output(out), y)
+                loss = nn.functional.mse_loss(self.adapt_output_for_metrics(out), y)
             # after train with nll
             else:
                 loss = self.loss_fn(out, y)
@@ -245,7 +245,7 @@ class SGLDRegression(SGLDBase):
         loss = sgld_opt.step(closure=closure)
 
         self.log("train_loss", loss)  # logging to Logger
-        self.train_metrics(self.extract_mean_output(out), y)
+        self.train_metrics(self.adapt_output_for_metrics(out), y)
 
         # return loss
 
@@ -332,8 +332,8 @@ class SGLDClassification(SGLDBase):
             "test", self.task, self.num_classes
         )
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract the mean output from model prediction.
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation.
 
         Args:
             out: output from :meth:`self.forward` [batch_size x (mu, sigma)]
@@ -371,7 +371,7 @@ class SGLDClassification(SGLDBase):
         loss = sgld_opt.step(closure=closure)
 
         self.log("train_loss", loss)  # logging to Logger
-        self.train_metrics(self.extract_mean_output(out), y)
+        self.train_metrics(self.adapt_output_for_metrics(out), y)
 
         return loss
 

--- a/lightning_uq_box/uq_methods/sgld.py
+++ b/lightning_uq_box/uq_methods/sgld.py
@@ -23,6 +23,7 @@ from .utils import (
     default_regression_metrics,
     process_classification_prediction,
     process_regression_prediction,
+    save_regression_predictions,
 )
 
 
@@ -169,6 +170,8 @@ class SGLDBase(DeterministicModel):
 class SGLDRegression(SGLDBase):
     """Stochastic Gradient Langevin Dynamics method for regression."""
 
+    pred_file_name = "preds.csv"
+
     def __init__(
         self,
         model: nn.Module,
@@ -269,6 +272,20 @@ class SGLDRegression(SGLDBase):
         # shape [batch_size, num_outputs, n_sgld_samples]
 
         return process_regression_prediction(preds)
+
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )
 
 
 class SGLDClassification(SGLDBase):

--- a/lightning_uq_box/uq_methods/swag.py
+++ b/lightning_uq_box/uq_methods/swag.py
@@ -481,8 +481,8 @@ class SWAGClassification(SWAGBase):
         )
         self.save_hyperparameters(ignore=["model", "loss_fn"])
 
-    def extract_mean_output(self, out: Tensor) -> Tensor:
-        """Extract mean output from model output.
+    def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
+        """Adapt model output to be compatible for metric computation.
 
         Args:
             out: output from the model

--- a/lightning_uq_box/uq_methods/swag.py
+++ b/lightning_uq_box/uq_methods/swag.py
@@ -26,6 +26,7 @@ for support of partial stochasticity and integration to lightning.
 """
 
 import math
+import os
 from collections import OrderedDict
 from copy import deepcopy
 from typing import Any, Dict, Optional, Union
@@ -45,6 +46,7 @@ from .utils import (
     process_classification_prediction,
     process_regression_prediction,
     process_segmentation_prediction,
+    save_regression_predictions,
 )
 
 
@@ -347,6 +349,8 @@ class SWAGRegression(SWAGBase):
     * https://proceedings.neurips.cc/paper_files/paper/2019/hash/118921efba23fc329e6560b27861f0c2-Abstract.html # noqa: E501
     """
 
+    pred_file_name = "preds.csv"
+
     def __init__(
         self,
         model: nn.Module,
@@ -387,6 +391,20 @@ class SWAGRegression(SWAGBase):
         """Set up task specific attributes."""
         self.test_metrics = default_regression_metrics("test")
 
+    def on_test_batch_end(
+        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Test batch end save predictions.
+
+        Args:
+            outputs: dictionary of model outputs and aux variables
+            batch_idx: batch index
+            dataloader_idx: dataloader index
+        """
+        save_regression_predictions(
+            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+        )
+
     def predict_step(
         self, X: Tensor, batch_idx: int = 0, dataloader_idx: int = 0
     ) -> Dict[str, Tensor]:
@@ -418,6 +436,7 @@ class SWAGClassification(SWAGBase):
     * https://proceedings.neurips.cc/paper_files/paper/2019/hash/118921efba23fc329e6560b27861f0c2-Abstract.html # noqa: E501
     """
 
+    pred_file_name = "preds.csv"
     valid_tasks = ["binary", "multiclass", "multilable"]
 
     def __init__(

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -167,8 +167,8 @@ def merge_list_of_dictionaries(list_of_dicts: list[dict[str, Any]]):
     return merged_dict
 
 
-def save_predictions_to_csv(outputs: dict[str, Tensor], path: str) -> None:
-    """Save model predictions to csv file.
+def save_regression_predictions(outputs: dict[str, Tensor], path: str) -> None:
+    """Save regression predictions to csv file.
 
     Args:
         outputs: metrics and values to be saved

--- a/tests/uq_methods/test_image_regression.py
+++ b/tests/uq_methods/test_image_regression.py
@@ -4,6 +4,7 @@
 """Test Image Regression Tasks."""
 
 import glob
+import os
 from pathlib import Path
 from typing import Any, Dict
 
@@ -56,6 +57,11 @@ class TestImageRegressionTask:
         trainer.fit(model, datamodule)
         trainer.test(ckpt_path="best", datamodule=datamodule)
 
+        # check that predictions are saved
+        assert os.path.exists(
+            os.path.join(trainer.default_root_dir, model.pred_file_name)
+        )
+
 
 ensemble_model_config_paths = [
     "tests/configs/image_regression/mc_dropout_nll.yaml",
@@ -104,3 +110,8 @@ class TestDeepEnsemble:
         datamodule = ToyImageRegressionDatamodule()
         trainer = Trainer()
         trainer.test(ensemble_model, datamodule=datamodule)
+
+        # check that predictions are saved
+        assert os.path.exists(
+            os.path.join(trainer.default_root_dir, ensemble_model.pred_file_name)
+        )

--- a/tests/uq_methods/test_regression.py
+++ b/tests/uq_methods/test_regression.py
@@ -4,6 +4,7 @@
 """Test Regression Tasks."""
 
 import glob
+import os
 from pathlib import Path
 from typing import Any, Dict
 
@@ -62,6 +63,11 @@ class TestRegressionTask:
         cli = get_uq_box_cli(args)
         cli.trainer.fit(cli.model, cli.datamodule)
         cli.trainer.test(ckpt_path="best", datamodule=cli.datamodule)
+
+        # assert predictions are saved
+        assert os.path.exists(
+            os.path.join(cli.trainer.default_root_dir, cli.model.pred_file_name)
+        )
 
 
 ensemble_model_config_paths = [
@@ -123,3 +129,7 @@ class TestDeepEnsemble:
         trainer = Trainer()
 
         trainer.test(ensemble_model, datamodule=datamodule)
+
+        assert os.path.exists(
+            os.path.join(trainer.default_root_dir, ensemble_model.pred_file_name)
+        )


### PR DESCRIPTION
Add back functionality that automatically saves predictions for 1D regression experiments, but now also unit tested. Additonally, change the name of `extract_mean_output` method which is really just implemented to make sure that from the variety of models and implementation we can extract a quantity that is used for logging the metrics for the task. So I changed it to `adapt_output_for_metrics`. Besides being more descriptive, it should make it more easier to adapt a model to more complicated architectures (multi-headed architectures for example).