### PR TITLE
Add MC-Dropout CP

### DIFF
--- a/lightning_uq_box/uq_methods/__init__.py
+++ b/lightning_uq_box/uq_methods/__init__.py
@@ -49,6 +49,7 @@ from .mc_dropout import (
     MCDropoutRegression,
     MCDropoutSegmentation,
 )
+from .mc_dropout_conformal import MCDropoutCPClassification, MCDropoutCPRegression
 from .mean_variance_estimation import MVEBase, MVERegression
 from .prob_unet import ProbUNet
 from .quantile_regression import QuantileRegression, QuantileRegressionBase
@@ -84,6 +85,9 @@ __all__ = (
     "MCDropoutRegression",
     "MCDropoutClassification",
     "MCDropoutSegmentation",
+    # MC-Dropout with Conformal Prediction
+    "MCDropoutCPClassification",
+    "MCDropoutCPRegression",
     # Laplace Approximation
     "LaplaceBase",
     "LaplaceRegression",

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -74,6 +74,7 @@ class MCDropoutBase(DeterministicModel):
         if not dropout_layer_names:
             dropout_layer_names = find_dropout_layers(model)
         self.dropout_layer_names = dropout_layer_names
+        self.num_mc_samples = num_mc_samples
 
     def setup_task(self) -> None:
         """Set up task specific attributes."""

--- a/lightning_uq_box/uq_methods/mc_dropout_conformal.py
+++ b/lightning_uq_box/uq_methods/mc_dropout_conformal.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the MIT License.
+
+"""Mc-Dropout Conformal Prediction."""
+
+import torch
+import torch.nn as nn
+from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+from torch import Tensor
+from torch.optim.adam import Adam
+
+from .mc_dropout import MCDropoutClassification, MCDropoutRegression
+from .utils import process_classification_prediction, process_regression_prediction
+
+
+class MCDropoutCPClassification(MCDropoutClassification):
+    """MC Dropout with Conformal Prediction for Classification.
+
+    If you use this method, please cite:
+
+    * https://arxiv.org/abs/2308.09647
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        num_mc_samples: int,
+        loss_fn: nn.Module,
+        patience: int = 10,
+        min_delta: float = 5e-4,
+        task: str = "multiclass",
+        dropout_layer_names: list[str] = [],
+        optimizer: OptimizerCallable = Adam,
+        lr_scheduler: LRSchedulerCallable = None,
+    ) -> None:
+        """Initialize MC Dropout with Conformal Prediction for Classification.
+
+        Args:
+            model: PyTorch model
+            num_mc_samples: number of MC samples
+            loss_fn: loss function
+            patience: how many forward passes to wait when all classes are lower than
+                the min_delta threshold
+            min_delta: considered stable if class value falls below this threshold
+            task: task type, either "binary" or "multiclass"
+            dropout_layer_names: list of names of dropout layers
+            optimizer: optimizer
+            lr_scheduler: learning rate scheduler
+        """
+        super().__init__(
+            model,
+            num_mc_samples,
+            loss_fn,
+            task,
+            dropout_layer_names,
+            optimizer,
+            lr_scheduler,
+        )
+        self.patience = patience
+        self.min_delta = min_delta
+
+    def predict_step(
+        self, X: Tensor, batch_idx: int = 0, dataloader_idx: int = 0
+    ) -> dict[str, Tensor]:
+        """Predict step with MC-Dropout using conformalised procedure.
+
+        Args:
+            X: prediction batch of shape [batch_size x input_dims]
+
+        Returns:
+            mean and standard deviation of MC predictions
+        """
+        self.activate_dropout()
+        preds = dynamic_mc_dropout_conformalised(
+            self.model, X, self.patience, self.min_delta, self.num_mc_samples
+        )
+        return process_classification_prediction(preds)
+
+
+class MCDropoutCPRegression(MCDropoutRegression):
+    """MC Dropout with Conformal Prediction for Regression.
+
+    If you use this method, please cite:
+
+    * https://arxiv.org/abs/2308.09647
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        num_mc_samples: int,
+        loss_fn: nn.Module,
+        patience: int = 10,
+        min_delta: float = 5e-4,
+        burnin_epochs: int = 0,
+        dropout_layer_names: list[str] = [],
+        optimizer: OptimizerCallable = Adam,
+        lr_scheduler: LRSchedulerCallable = None,
+    ) -> None:
+        """Initialize MC Dropout with Conformal Prediction for Regression.
+
+        Args:
+            model: PyTorch model
+            num_mc_samples: number of MC samples
+            loss_fn: loss function
+            patience: how many forward passes to wait when all classes are lower than
+                the min_delta threshold
+            min_delta: considered stable if class value falls below this threshold
+            burnin_epochs: number of epochs to wait before switching to loss function
+            dropout_layer_names: list of names of dropout layers
+            optimizer: optimizer
+            lr_scheduler: learning rate scheduler
+        """
+        super().__init__(
+            model,
+            num_mc_samples,
+            loss_fn,
+            burnin_epochs,
+            dropout_layer_names,
+            optimizer,
+            lr_scheduler,
+        )
+        self.patience = patience
+        self.min_delta = min_delta
+
+    def predict_step(
+        self, X: Tensor, batch_idx: int = 0, dataloader_idx: int = 0
+    ) -> dict[str, Tensor]:
+        """Predict step with MC-Dropout using conformalised procedure.
+
+        Args:
+            X: prediction batch of shape [batch_size x input_dims]
+
+        Returns:
+            mean and standard deviation of MC predictions
+        """
+        self.activate_dropout()
+        preds = dynamic_mc_dropout_conformalised(
+            self.model, X, self.patience, self.min_delta, self.num_mc_samples
+        )
+        return process_regression_prediction(preds)
+
+
+def dynamic_mc_dropout_conformalised(
+    model: nn.Module, X: Tensor, patience: int, min_delta: float, max_num_samples: int
+) -> Tensor:
+    """MC Dropout with Conformal Prediction for Regression.
+
+    If you use this method, please cite:
+
+    * https://arxiv.org/abs/2308.09647
+
+    Args:
+        model: PyTorch model
+        X: prediction batch of shape [batch_size x input_dims]
+        patience: how many forward passes to wait when all classes are lower than
+            the min_delta threshold
+        min_delta: the threshold a class how to be lower than to be considered stable
+        max_num_samples: maximum number of MC samples to collect
+
+    Returns:
+        stacked prediction tensor of shape [batch_size x num_outputs x num_mc_samples]
+    """
+    std_diffs = []
+    with torch.no_grad():
+        current_patience = 0
+        prev_std: Tensor = torch.zeros(1)
+        predictions = []
+        while current_patience <= patience or len(predictions) == max_num_samples:
+            pred = model(X)
+            predictions.append(pred)
+            std = pred.std(dim=0)
+            if len(predictions) != 1:
+                std_diff = torch.abs(std - prev_std)
+                std_diffs.append(std_diff)
+                if torch.all(std_diff <= min_delta):
+                    current_patience += 1
+                else:
+                    current_patience = 0
+
+            prev_std = std
+
+    preds = torch.stack(predictions, dim=-1)
+    return preds

--- a/tests/configs/image_classification/mc_conformal.yaml
+++ b/tests/configs/image_classification/mc_conformal.yaml
@@ -1,0 +1,19 @@
+model:
+  _target_: lightning_uq_box.uq_methods.MCDropoutCPClassification
+  model:
+    _target_: timm.create_model
+    model_name: resnet18
+    num_classes: 2
+    drop_rate: 0.1
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 0.003
+  lr_scheduler:
+    _target_: torch.optim.lr_scheduler.ConstantLR
+    _partial_: true
+  loss_fn:
+    _target_: torch.nn.CrossEntropyLoss
+  num_mc_samples: 20
+  min_delta: 0.1
+  patience: 10

--- a/tests/configs/regression/mc_conformal.yaml
+++ b/tests/configs/regression/mc_conformal.yaml
@@ -1,0 +1,22 @@
+model:
+  class_path: lightning_uq_box.uq_methods.MCDropoutCPRegression
+  init_args:
+    model:
+      class_path: lightning_uq_box.models.MLP
+      init_args:
+        n_outputs: 1
+        n_hidden: [50]
+        dropout_p: 0.1
+        activation_fn:
+          class_path: torch.nn.ReLU
+    optimizer:
+      class_path: torch.optim.Adam
+      init_args:
+        lr: 0.003
+    loss_fn:
+      class_path: torch.nn.MSELoss
+    lr_scheduler:
+      class_path: torch.optim.lr_scheduler.ConstantLR
+    num_mc_samples: 20
+    patience: 10
+    min_delta: 0.1

--- a/tests/uq_methods/test_image_classification.py
+++ b/tests/uq_methods/test_image_classification.py
@@ -25,6 +25,7 @@ model_config_paths = [
     "tests/configs/image_classification/due.yaml",
     "tests/configs/image_classification/laplace.yaml",
     "tests/configs/image_classification/card.yaml",
+    "tests/configs/image_classification/mc_conformal.yaml",
 ]
 
 data_config_paths = ["tests/configs/image_classification/toy_classification.yaml"]

--- a/tests/uq_methods/test_regression.py
+++ b/tests/uq_methods/test_regression.py
@@ -35,6 +35,7 @@ model_config_paths = [
     "tests/configs/regression/dkl.yaml",
     "tests/configs/regression/due.yaml",
     "tests/configs/regression/cards.yaml",
+    "tests/configs/regression/mc_conformal.yaml",
 ]
 
 data_config_paths = ["tests/configs/regression/toy_regression.yaml"]


### PR DESCRIPTION
This PR adds the MC-CP method from the paper [Robust Uncertainty Quantification using Conformalised Monte Carlo Prediction Bethell et al. 2023 ](https://arxiv.org/abs/2308.09647), based on the accompanying [repo](https://github.com/team-daniel/MC-CP/blob/master/AAAISupplementaryCode.ipynb).