### PR TITLE
Freeze backbone/encoder/decoder utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,45 +46,43 @@ The following sections aims to give an overview of different UQ-Methods by group
 
 ### Single Forward Pass Methods
 
-| UQ-Method            | Regression            | Classification            | Segmentation              | Pixel Wise Regression      |
-|----------------------|:---------------------:|:-------------------------:|:-------------------------:|:--------------------------:|
-| Quantile Regression  |          ✅           |           ❌              |           ❌              |            ⏳            |
-| Deep Evidential      |          ✅           |           ⏳              |           ⏳              |            ⏳            |
-| MVE                  |          ✅           |           ❌              |           ❌              |            ⏳            |
-
+| Uncertainty Quantification Method (UQ-Method) | Regression | Classification | Segmentation | Pixel Wise Regression |
+|-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
+| Quantile Regression (QR)                      |     ✅     |       ❌       |      ❌      |          ⏳           |
+| Deep Evidential (DE)                          |     ✅     |       ⏳       |      ⏳      |          ⏳           |
+| Mean Variance Estimation (MVE)                |     ✅     |       ❌       |      ❌      |          ⏳           |
 
 ### Approximate Bayesian Methods
 
-| UQ-Method            | Regression            | Classification            | Segmentation              | Pixel Wise Regression      |
-|----------------------|:---------------------:|:-------------------------:|:-------------------------:|:--------------------------:|
-| BNN_VI_ELBO          |          ✅           |           ✅              |           ✅              |            ⏳            |
-| BNN_VI               |          ✅           |           ⏳              |           ⏳              |            ⏳            |
-| DKL                  |          ✅           |           ✅              |           ❌              |            ⏳            |
-| DUE                  |          ✅           |           ✅              |           ❌              |            ⏳            |
-| Laplace              |          ✅           |           ✅              |           ❌              |            ⏳            |
-| MC-Dropout           |          ✅           |           ✅              |           ✅              |            ⏳            |
-| SGLD                 |          ✅           |           ✅              |           ⏳              |            ⏳            |
-| SNGP                 |          ✅           |           ✅              |           ❌              |            ❌            |
-| SWAG                 |          ✅           |           ✅              |           ✅              |            ⏳            |
-| Deep Ensemble        |          ✅           |           ✅              |           ✅              |            ⏳            |
+| Uncertainty Quantification Method (UQ-Method) | Regression | Classification | Segmentation | Pixel Wise Regression |
+|-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
+| Bayesian Neural Network VI ELBO (BNN_VI_ELBO) |     ✅     |       ✅       |      ✅      |          ⏳           |
+| Bayesian Neural Network VI (BNN_VI)           |     ✅     |       ⏳       |      ⏳      |          ⏳           |
+| Deep Kernel Learning (DKL)                    |     ✅     |       ✅       |      ❌      |          ❌           |
+| Deterministic Uncertainty Estimation (DUE)    |     ✅     |       ✅       |      ❌      |          ❌           |
+| Laplace Approximation (Laplace)               |     ✅     |       ✅       |      ❌      |          ❌           |
+| Monte Carlo Dropout (MC-Dropout)              |     ✅     |       ✅       |      ✅      |          ⏳           |
+| Stochastic Gradient Langevin Dynamics (SGLD)  |     ✅     |       ✅       |      ⏳      |          ⏳           |
+| Spectral Normalized Gaussian Process (SNGP)   |     ✅     |       ✅       |      ❌      |          ❌           |
+| Stochastic Weight Averaging Gaussian (SWAG)   |     ✅     |       ✅       |      ✅      |          ⏳           |
+| Deep Ensemble                                 |     ✅     |       ✅       |      ✅      |          ⏳           |
 
 ### Generative Models
 
-| UQ-Method                      | Regression | Classification | Segmentation | Pixel Wise Regression |
-|--------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
-| CARD                           |     ✅     |       ✅       |      ❌      |          ❌           |
-| Probabilistic UNet             |     ❌     |       ❌       |      ✅      |          ❌           |
-| Hierarchical Probabilistic UNet|     ❌     |       ❌       |      ✅      |          ❌           |
-
+| Uncertainty Quantification Method (UQ-Method) | Regression | Classification | Segmentation | Pixel Wise Regression |
+|-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
+| Classification And Regression Diffusion (CARD)|     ✅     |       ✅       |      ❌      |          ❌           |
+| Probabilistic UNet                            |     ❌     |       ❌       |      ✅      |          ❌           |
+| Hierarchical Probabilistic UNet               |     ❌     |       ❌       |      ✅      |          ❌           |
 
 ### Post-Hoc methods
 
-| UQ-Method            | Regression            | Classification            | Segmentation              | Pixel Wise Regression      |
-|----------------------|:---------------------:|:-------------------------:|:-------------------------:|:--------------------------:|
-| Test Time Augmentation|          ✅            |           ✅              |           ⏳               |            ⏳               |
-| Temperature Scaling  |          ❌           |           ✅              |           ⏳              |            ❌              |
-| Conformal QR         |          ✅           |           ❌              |           ❌              |            ⏳              |
-| RAPS                 |          ❌           |           ✅              |           ❌              |            ❌              |
+| Uncertainty Quantification Method (UQ-Method) | Regression | Classification | Segmentation | Pixel Wise Regression |
+|-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
+| Test Time Augmentation (TTA)                  |     ✅     |       ✅       |      ⏳      |          ⏳           |
+| Temperature Scaling                           |     ❌     |       ✅       |      ⏳      |          ❌           |
+| Conformal Quantile Regression (Conformal QR)  |     ✅     |       ❌       |      ❌      |          ⏳           |
+| Regularized Adaptive Prediction Sets (RAPS)   |     ❌     |       ✅       |      ❌      |          ❌           |
 
 # Tutorials
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,46 +21,43 @@ The following sections aims to give an overview of different UQ-Methods by group
 
 ### Single Forward Pass Methods
 
-| UQ-Method            | Regression            | Classification            | Segmentation              | Pixel Wise Regression      |
-|----------------------|:---------------------:|:-------------------------:|:-------------------------:|:--------------------------:|
-| Quantile Regression  |          ✅           |           ❌              |           ❌              |            ⏳            |
-| Deep Evidential      |          ✅           |           ⏳              |           ⏳              |            ⏳            |
-| MVE                  |          ✅           |           ❌              |           ❌              |            ⏳            |
-
+| Uncertainty Quantification Method (UQ-Method) | Regression | Classification | Segmentation | Pixel Wise Regression |
+|-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
+| Quantile Regression (QR)                      |     ✅     |       ❌       |      ❌      |          ⏳           |
+| Deep Evidential (DE)                          |     ✅     |       ⏳       |      ⏳      |          ⏳           |
+| Mean Variance Estimation (MVE)                |     ✅     |       ❌       |      ❌      |          ⏳           |
 
 ### Approximate Bayesian Methods
 
-| UQ-Method            | Regression            | Classification            | Segmentation              | Pixel Wise Regression      |
-|----------------------|:---------------------:|:-------------------------:|:-------------------------:|:--------------------------:|
-| BNN_VI_ELBO          |          ✅           |           ✅              |           ✅              |            ⏳            |
-| BNN_VI               |          ✅           |           ⏳              |           ⏳              |            ⏳            |
-| DKL                  |          ✅           |           ✅              |           ❌              |            ⏳            |
-| DUE                  |          ✅           |           ✅              |           ❌              |            ⏳            |
-| Laplace              |          ✅           |           ✅              |           ❌              |            ⏳            |
-| MC-Dropout           |          ✅           |           ✅              |           ✅              |            ⏳            |
-| SGLD                 |          ✅           |           ✅              |           ⏳              |            ⏳            |
-| SNGP                 |          ✅           |           ✅              |           ❌              |            ❌            |
-| SWAG                 |          ✅           |           ✅              |           ✅              |            ⏳            |
-| Deep Ensemble        |          ✅           |           ✅              |           ✅              |            ⏳            |
-
+| Uncertainty Quantification Method (UQ-Method) | Regression | Classification | Segmentation | Pixel Wise Regression |
+|-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
+| Bayesian Neural Network VI ELBO (BNN_VI_ELBO) |     ✅     |       ✅       |      ✅      |          ⏳           |
+| Bayesian Neural Network VI (BNN_VI)           |     ✅     |       ⏳       |      ⏳      |          ⏳           |
+| Deep Kernel Learning (DKL)                    |     ✅     |       ✅       |      ❌      |          ❌           |
+| Deterministic Uncertainty Estimation (DUE)    |     ✅     |       ✅       |      ❌      |          ❌           |
+| Laplace Approximation (Laplace)               |     ✅     |       ✅       |      ❌      |          ❌           |
+| Monte Carlo Dropout (MC-Dropout)              |     ✅     |       ✅       |      ✅      |          ⏳           |
+| Stochastic Gradient Langevin Dynamics (SGLD)  |     ✅     |       ✅       |      ⏳      |          ⏳           |
+| Spectral Normalized Gaussian Process (SNGP)   |     ✅     |       ✅       |      ❌      |          ❌           |
+| Stochastic Weight Averaging Gaussian (SWAG)   |     ✅     |       ✅       |      ✅      |          ⏳           |
+| Deep Ensemble                                 |     ✅     |       ✅       |      ✅      |          ⏳           |
 
 ### Generative Models
 
-| UQ-Method                      | Regression | Classification | Segmentation | Pixel Wise Regression |
-|--------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
-| CARD                           |     ✅     |       ✅       |      ❌      |          ❌           |
-| Probabilistic UNet             |     ❌     |       ❌       |      ✅      |          ❌           |
-| Hierarchical Probabilistic UNet|     ❌     |       ❌       |      ✅      |          ❌           |
-
+| Uncertainty Quantification Method (UQ-Method) | Regression | Classification | Segmentation | Pixel Wise Regression |
+|-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
+| Classification And Regression Diffusion (CARD)|     ✅     |       ✅       |      ❌      |          ❌           |
+| Probabilistic UNet                            |     ❌     |       ❌       |      ✅      |          ❌           |
+| Hierarchical Probabilistic UNet               |     ❌     |       ❌       |      ✅      |          ❌           |
 
 ### Post-Hoc methods
 
-| UQ-Method            | Regression            | Classification            | Segmentation              | Pixel Wise Regression      |
-|----------------------|:---------------------:|:-------------------------:|:-------------------------:|:--------------------------:|
-| Test Time Augmentation|          ✅            |           ✅              |           ⏳               |            ⏳               |
-| Temperature Scaling  |          ❌           |           ✅              |           ⏳              |            ❌              |
-| Conformal QR         |          ✅           |           ❌              |           ❌              |            ⏳              |
-| RAPS                 |          ❌           |           ✅              |           ❌              |            ❌              |
+| Uncertainty Quantification Method (UQ-Method) | Regression | Classification | Segmentation | Pixel Wise Regression |
+|-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
+| Test Time Augmentation (TTA)                  |     ✅     |       ✅       |      ⏳      |          ⏳           |
+| Temperature Scaling                           |     ❌     |       ✅       |      ⏳      |          ❌           |
+| Conformal Quantile Regression (Conformal QR)  |     ✅     |       ❌       |      ❌      |          ⏳           |
+| Regularized Adaptive Prediction Sets (RAPS)   |     ❌     |       ✅       |      ❌      |          ❌           |
 
 
 ## Table of contents

--- a/docs/tutorial_overview.md
+++ b/docs/tutorial_overview.md
@@ -12,6 +12,8 @@ The tutorials have two central goals:
 
 ## Regression 1D targets
 
+These tutorials present the regression methods on a 1D toy dataset. However, the methods are equally equipped to handle other data modalities, for example image regression by swapping out the underlying network architecture.
+
 ```{toctree}
 :maxdepth: 1
 
@@ -19,6 +21,8 @@ tutorials/regression
 ```
 
 ## Classification
+
+These tutorials present the classification methods on a Two Moons toy dataset. However, the methods are equally equipped to handle other data modalities, for example image classification by swapping out the underlying network architecture.
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -10,9 +10,8 @@ With that comes the integration of [Lightning-CLI](https://lightning.ai/docs/pyt
 
 The following aims to explain the design choices behind the implementations found in the Lightning-UQ-Box. We will first give some "definitions" about how we are using the three terms "UQ-Method", "Application Task", "Task Data Modalities".
 
-### Observations around terms
 
-#### UQ-Method
+### UQ-Method
 - a methodology developed that can be applied to a Neural Network and extract or
   enhance predictive uncertainty estimates
 - the methodology can be of different nature, for example:
@@ -26,7 +25,7 @@ The following aims to explain the design choices behind the implementations foun
   - how regression output from samples are computed is the same for MCDropout,
     SWAG, Ensembles etc (Gaussian moment matching)
 
-#### Application Task
+### Application Task
 - a task that is defined by the problem setting for which you have labels
 - regression,classification, segmentation, pixel wise regression, object
   detection, change detection etc.
@@ -34,13 +33,13 @@ The following aims to explain the design choices behind the implementations foun
 - however, there are also several commonalities across a subset of methods
   given any particular application task
 
-#### Task Data Modalities
+### Task Data Modalities
 - a specific application task can involve different data modalities
 - regression task could be vector inputs and single target output, or image
   input with single target output, or image input with multiple regression
   targets etc.
 
-### Design
+## Design
 
 - modular design aiming to:
   - give enough structure to apply any particular method to a
@@ -58,11 +57,11 @@ The following aims to explain the design choices behind the implementations foun
   implemented in the subclasses but can be util functions that could still be utilized by users for their own usage
 - try to integrate existing implementations into this framework to not reinvent the wheel
 
-### Pytorch and Lightning
+## Pytorch and Lightning
 - use [PyTorch](https://pytorch.org/docs/stable/index.html), because:
   - wide adaptation in research community
   - ready to use architectures and pretrained models for example through [timm library](https://github.com/huggingface/pytorch-image-models)
-    or [segmentation-models-pytorch](https://github.com/qubvel/segmentation_models.pytorch)
+    or [torchseg](https://github.com/isaaccorley/torchseg)
 - use [Lightning](https://lightning.ai/docs/pytorch/stable/), because:
   - reduces boiler plate code
   - enforces code organization structure

--- a/lightning_uq_box/datamodules/toy_image_classification.py
+++ b/lightning_uq_box/datamodules/toy_image_classification.py
@@ -12,18 +12,19 @@ from lightning_uq_box.datasets import ToyImageClassificationDataset
 class ToyImageClassificationDatamodule(LightningDataModule):
     """Toy Image Classification Datamodule for Testing."""
 
-    def __init__(self) -> None:
+    def __init__(self, **kwargs) -> None:
         """Initialize a new instance of Toy Image Classification Datamodule."""
         super().__init__()
+        self.kwargs = kwargs
 
     def train_dataloader(self) -> DataLoader:
         """Return Train Dataloader."""
-        return DataLoader(ToyImageClassificationDataset(), batch_size=10)
+        return DataLoader(ToyImageClassificationDataset(**self.kwargs), batch_size=10)
 
     def val_dataloader(self) -> DataLoader:
         """Return Val Dataloader."""
-        return DataLoader(ToyImageClassificationDataset(), batch_size=10)
+        return DataLoader(ToyImageClassificationDataset(**self.kwargs), batch_size=10)
 
     def test_dataloader(self) -> DataLoader:
         """Return Test Dataloader."""
-        return DataLoader(ToyImageClassificationDataset(), batch_size=10)
+        return DataLoader(ToyImageClassificationDataset(**self.kwargs), batch_size=10)

--- a/lightning_uq_box/datasets/toy_image_classification.py
+++ b/lightning_uq_box/datasets/toy_image_classification.py
@@ -10,13 +10,23 @@ from torch.utils.data import Dataset
 class ToyImageClassificationDataset(Dataset):
     """Toy Image Classification Dataset."""
 
-    def __init__(self, num_classes: int = 4, num_samples: int = 10) -> None:
-        """Initialize a new instance of Toy Image Classification Dataset."""
+    def __init__(
+        self, num_classes: int = 4, num_samples: int = 10, img_size: int = 64
+    ) -> None:
+        """Initialize a new instance of Toy Image Classification Dataset.
+
+        Args:
+            num_classes: number of classes in the dataset
+            num_samples: number of samples in the dataset
+            img_size: size of the image
+        """
         super().__init__()
 
         self.num_samples = num_samples
         self.num_classes = num_classes
-        self.images = [torch.randn(3, 64, 64) for val in range(self.num_samples)]
+        self.images = [
+            torch.randn(3, img_size, img_size) for val in range(self.num_samples)
+        ]
         self.targets = torch.randint(0, self.num_classes, (self.num_samples,))
 
     def __len__(self):

--- a/lightning_uq_box/uq_methods/__init__.py
+++ b/lightning_uq_box/uq_methods/__init__.py
@@ -8,6 +8,7 @@ from .base import (
     DeterministicClassification,
     DeterministicModel,
     DeterministicRegression,
+    DeterministicSegmentation,
     PosthocBase,
 )
 from .bnn_lv_vi import (
@@ -74,6 +75,7 @@ __all__ = (
     "DeterministicModel",
     "DeterministicClassification",
     "DeterministicRegression",
+    "DeterministicSegmentation",
     # CARDS
     "CARDBase",
     "CARDRegression",

--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -110,12 +110,7 @@ class DeterministicModel(BaseModule):
 
     def setup_task(self) -> None:
         """Set up task specific attributes."""
-        self.freeze_model()
         raise NotImplementedError
-
-    def freeze_model(self) -> None:
-        """Freeze model backbone."""
-        pass
 
     def adapt_output_for_metrics(self, out: Tensor) -> Tensor:
         """Adapt model output to be compatible for metric computation.

--- a/lightning_uq_box/uq_methods/bnn_vi_elbo.py
+++ b/lightning_uq_box/uq_methods/bnn_vi_elbo.py
@@ -22,6 +22,7 @@ from .utils import (
     default_classification_metrics,
     default_regression_metrics,
     default_segmentation_metrics,
+    freeze_model_backbone,
     map_stochastic_modules,
     process_classification_prediction,
     process_regression_prediction,
@@ -53,6 +54,7 @@ class BNN_VI_ELBO_Base(DeterministicModel):
         posterior_rho_init: float = -5.0,
         bayesian_layer_type: str = "reparameterization",
         stochastic_module_names: Optional[list[Union[int, str]]] = None,
+        freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
         lr_scheduler: LRSchedulerCallable = None,
     ) -> None:
@@ -76,6 +78,7 @@ class BNN_VI_ELBO_Base(DeterministicModel):
             bayesian_layer_type: `flipout` or `reparameterization`
             stochastic_module_names: list of module names or indices that should
                 be converted to variational layers
+            freeze_backbone: whether to freeze the backbone
             optimizer: optimizer used for training
             lr_scheduler: learning rate scheduler
 
@@ -106,9 +109,17 @@ class BNN_VI_ELBO_Base(DeterministicModel):
         self.criterion = criterion
         self.lr_scheduler = lr_scheduler
 
+        self.freeze_backbone = freeze_backbone
+        self.freeze_model()
+
     def setup_task(self) -> None:
         """Set up task."""
         pass
+
+    def freeze_model(self) -> None:
+        """Freeze the model backbone."""
+        if self.freeze_backbone:
+            freeze_model_backbone(self.model)
 
     def _setup_bnn_with_vi(self) -> None:
         """Configure setup of the BNN Model."""
@@ -309,6 +320,7 @@ class BNN_VI_ELBO_Regression(BNN_VI_ELBO_Base):
         posterior_rho_init: float = -5,
         bayesian_layer_type: str = "reparameterization",
         stochastic_module_names: Optional[Union[list[int], list[str]]] = None,
+        freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
         lr_scheduler: LRSchedulerCallable = None,
     ) -> None:
@@ -333,6 +345,7 @@ class BNN_VI_ELBO_Regression(BNN_VI_ELBO_Base):
             bayesian_layer_type: `flipout` or `reparameterization`
             stochastic_module_names: list of module names or indices that should
                 be converted to variational layers
+            freeze_backbone: whether to freeze the backbone
             optimizer: optimizer used for training
             lr_scheduler: learning rate scheduler
 
@@ -353,6 +366,7 @@ class BNN_VI_ELBO_Regression(BNN_VI_ELBO_Base):
             posterior_rho_init,
             bayesian_layer_type,
             stochastic_module_names,
+            freeze_backbone,
             optimizer,
             lr_scheduler,
         )
@@ -445,6 +459,7 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
         posterior_rho_init: float = -5,
         bayesian_layer_type: str = "reparameterization",
         stochastic_module_names: Optional[Union[list[int], list[str]]] = None,
+        freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
         lr_scheduler: LRSchedulerCallable = None,
     ) -> None:
@@ -469,6 +484,7 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
             bayesian_layer_type: `flipout` or `reparameterization`
             stochastic_module_names: list of module names or indices that should
                 be converted to variational layers
+            freeze_backbone: whether to freeze the backbone
             lr_scheduler: learning rate scheduler
             optimizer: optimizer used for training
 
@@ -494,6 +510,7 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
             posterior_rho_init,
             bayesian_layer_type,
             stochastic_module_names,
+            freeze_backbone,
             optimizer,
             lr_scheduler,
         )

--- a/lightning_uq_box/uq_methods/bnn_vi_elbo.py
+++ b/lightning_uq_box/uq_methods/bnn_vi_elbo.py
@@ -23,6 +23,7 @@ from .utils import (
     default_regression_metrics,
     default_segmentation_metrics,
     freeze_model_backbone,
+    freeze_segmentation_model,
     map_stochastic_modules,
     process_classification_prediction,
     process_regression_prediction,
@@ -586,6 +587,83 @@ class BNN_VI_ELBO_Segmentation(BNN_VI_ELBO_Classification):
 
     * https://arxiv.org/abs/1505.05424
     """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        criterion: nn.Module,
+        task: str = "multiclass",
+        beta: float = 100,
+        num_mc_samples_train: int = 10,
+        num_mc_samples_test: int = 50,
+        output_noise_scale: float = 1.3,
+        prior_mu: float = 0,
+        prior_sigma: float = 1,
+        posterior_mu_init: float = 0,
+        posterior_rho_init: float = -5,
+        bayesian_layer_type: str = "reparameterization",
+        stochastic_module_names: Optional[Union[list[int], list[str]]] = None,
+        freeze_backbone: bool = False,
+        freeze_decoder: bool = False,
+        optimizer: OptimizerCallable = torch.optim.Adam,
+        lr_scheduler: LRSchedulerCallable = None,
+    ) -> None:
+        """Initialize a new BNN VI ELBO Segmentation instance.
+
+        Args:
+            model: pytorch model that will be converted into a BNN
+            criterion: loss function used for optimization
+            task: classification task, one of `binary`, `multiclass`, `multilabel`
+            beta: beta factor for negative elbo loss computation,
+                should be number of weights and biases
+            num_mc_samples_train: number of MC samples during training when computing
+                the negative ELBO loss. When setting num_mc_samples_train=1, this
+                is just Bayes by Backprop.
+            num_mc_samples_test: number of MC samples during test and prediction
+            output_noise_scale: scale of predicted sigmas
+            prior_mu: prior mean value for bayesian layer
+            prior_sigma: prior variance value for bayesian layer
+            posterior_mu_init: mean initialization value for approximate posterior
+            posterior_rho_init: variance initialization value for approximate posterior
+                through softplus σ = log(1 + exp(ρ))
+            bayesian_layer_type: `flipout` or `reparameterization`
+            stochastic_module_names: list of module names or indices that should
+                be converted to variational layers
+            freeze_backbone: whether to freeze the model backbone, by default this is
+                supported for torchseg Unet models
+            freeze_decoder: whether to freeze the model decoder, by default this is
+                supported for torchseg Unet models
+            lr_scheduler: learning rate scheduler
+            optimizer: optimizer used for training
+        """
+        self.freeze_backbone = freeze_backbone
+        self.freeze_decoder = freeze_decoder
+        super().__init__(
+            model,
+            criterion,
+            task,
+            beta,
+            num_mc_samples_train,
+            num_mc_samples_test,
+            output_noise_scale,
+            prior_mu,
+            prior_sigma,
+            posterior_mu_init,
+            posterior_rho_init,
+            bayesian_layer_type,
+            stochastic_module_names,
+            freeze_backbone,
+            optimizer,
+            lr_scheduler,
+        )
+
+    def freeze_model(self) -> None:
+        """Freeze model backbone.
+
+        By default, assumes a timm model with a backbone and head.
+        Alternatively, selected the last layer with parameters to freeze.
+        """
+        freeze_segmentation_model(self.model, self.freeze_backbone, self.freeze_decoder)
 
     def setup_task(self) -> None:
         """Set up task specific attributes for segmentation."""

--- a/lightning_uq_box/uq_methods/deep_evidential_regression.py
+++ b/lightning_uq_box/uq_methods/deep_evidential_regression.py
@@ -15,6 +15,7 @@ from .loss_functions import DERLoss
 from .utils import (
     _get_num_outputs,
     default_regression_metrics,
+    freeze_model_backbone,
     save_regression_predictions,
 )
 
@@ -69,6 +70,7 @@ class DER(DeterministicModel):
         self,
         model: nn.Module,
         coeff: float = 0.01,
+        freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
         lr_scheduler: LRSchedulerCallable = None,
     ) -> None:
@@ -78,6 +80,7 @@ class DER(DeterministicModel):
             model: pytorch model
             coeff: coefficient for the DER loss
                 from the predictive distribution
+            freeze_backbone: whether to freeze the backbone
             optimizer: optimizer used for training
             lr_scheduler: learning rate scheduler
         """
@@ -90,6 +93,10 @@ class DER(DeterministicModel):
 
         # add DER Layer
         self.model = nn.Sequential(self.model, DERLayer())
+
+        self.freeze_backbone = freeze_backbone
+        if self.freeze_backbone:
+            freeze_model_backbone(self.model[0])
 
         # set DER Loss
         # TODO need to give control over the coeff through config or argument

--- a/lightning_uq_box/uq_methods/deterministic_uncertainty_estimation.py
+++ b/lightning_uq_box/uq_methods/deterministic_uncertainty_estimation.py
@@ -31,6 +31,7 @@ class DUERegression(DKLRegression):
         gp_kernel: str = "RBF",
         coeff: float = 0.95,
         n_power_iterations: int = 1,
+        freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
         lr_scheduler: LRSchedulerCallable = None,
     ) -> None:
@@ -48,6 +49,7 @@ class DUERegression(DKLRegression):
             coeff: soft normalization only when sigma larger than coeff,
                 should be (0, 1)
             n_power_iterations: number of power iterations for spectral normalization
+            freeze_backbone: whether to freeze the feature extractor or not
             optimizer: optimizer used for training
             lr_scheduler: learning rate scheduler
         """
@@ -64,6 +66,7 @@ class DUERegression(DKLRegression):
             n_inducing_points,
             num_targets,
             gp_kernel,
+            freeze_backbone,
             optimizer,
             lr_scheduler,
         )
@@ -87,6 +90,7 @@ class DUEClassification(DKLClassification):
         task: str = "multiclass",
         coeff: float = 0.95,
         n_power_iterations: int = 1,
+        freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
         lr_scheduler: LRSchedulerCallable = None,
     ) -> None:
@@ -102,6 +106,7 @@ class DUEClassification(DKLClassification):
             task: classification task, one of ['binary', 'multiclass', 'multilabel']
             coeff: soft normalization only when sigma larger than coeff should be (0, 1)
             n_power_iterations: number of power iterations for spectral normalization
+            freeze_backbone: whether to freeze the feature extractor or not
             optimizer: optimizer used for training
             lr_scheduler: learning rate scheduler
         """
@@ -119,6 +124,7 @@ class DUEClassification(DKLClassification):
             num_classes,
             task,
             gp_kernel,
+            freeze_backbone,
             optimizer,
             lr_scheduler,
         )

--- a/lightning_uq_box/uq_methods/hierarchical_prob_unet.py
+++ b/lightning_uq_box/uq_methods/hierarchical_prob_unet.py
@@ -444,6 +444,8 @@ class HierarchicalProbUNet(BaseModule):
         # compute metrics with sampled reconstruction
         self.test_metrics(preds["logits"], batch[self.target_key])
 
+        preds = self.add_aux_data_to_dict(preds, batch)
+
         return preds
 
     def predict_step(

--- a/lightning_uq_box/uq_methods/inference_time_augmentation.py
+++ b/lightning_uq_box/uq_methods/inference_time_augmentation.py
@@ -114,6 +114,8 @@ class TTABase(PosthocBase):
 
         merged_aug_preds[self.target_key] = batch[self.target_key]
 
+        merged_aug_preds = self.add_aux_data_to_dict(merged_aug_preds, batch)
+
         return merged_aug_preds
 
     def predict_step(

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -7,7 +7,6 @@ import os
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from torch import Tensor
 
@@ -332,11 +331,7 @@ class MCDropoutClassification(MCDropoutBase):
         self.activate_dropout()  # activate dropout during prediction
         with torch.no_grad():
             preds = torch.stack(
-                [
-                    F.softmax(self.model(X), dim=1)
-                    for _ in range(self.hparams.num_mc_samples)
-                ],
-                dim=-1,
+                [self.model(X) for _ in range(self.hparams.num_mc_samples)], dim=-1
             )  # shape [batch_size, num_outputs, num_samples]
 
         return process_classification_prediction(preds)

--- a/lightning_uq_box/uq_methods/prob_unet.py
+++ b/lightning_uq_box/uq_methods/prob_unet.py
@@ -313,6 +313,8 @@ class ProbUNet(BaseModule):
         # compute metrics with sampled reconstruction
         self.test_metrics(preds["logits"], batch[self.target_key])
 
+        preds = self.add_aux_data_to_dict(preds, batch)
+
         return preds
 
     def predict_step(

--- a/lightning_uq_box/uq_methods/raps.py
+++ b/lightning_uq_box/uq_methods/raps.py
@@ -117,6 +117,7 @@ class RAPS(PosthocBase):
         # need to set manually because of inference mode
         self.eval()
         pred_dict = self.predict_step(batch[self.input_key])
+        pred_dict[self.target_key] = batch[self.target_key]
 
         # logging metrics
         self.log(

--- a/lightning_uq_box/uq_methods/raps.py
+++ b/lightning_uq_box/uq_methods/raps.py
@@ -121,6 +121,7 @@ class RAPS(PosthocBase):
             batch_size=batch[self.input_key].shape[0],
         )
         self.test_metrics(pred_dict["pred"], batch[self.target_key])
+        pred_dict = self.add_aux_data_to_dict(pred_dict, batch)
         return pred_dict
 
     def predict_step(

--- a/lightning_uq_box/uq_methods/sngp.py
+++ b/lightning_uq_box/uq_methods/sngp.py
@@ -260,6 +260,7 @@ class SNGPBase(BaseModule):
         if batch[self.target_key].shape[0] > 1:
             self.test_metrics(pred_dict["pred"], batch[self.target_key])
 
+        pred_dict = self.add_aux_data_to_dict(pred_dict, batch)
         del pred_dict["pred_cov"]
         return pred_dict
 

--- a/lightning_uq_box/uq_methods/sngp.py
+++ b/lightning_uq_box/uq_methods/sngp.py
@@ -254,7 +254,7 @@ class SNGPBase(BaseModule):
             predictions
         """
         pred_dict = self.predict_step(batch[self.input_key])
-
+        pred_dict[self.target_key] = batch[self.target_key]
         loss = self.loss_fn(pred_dict["pred"], batch[self.target_key])
         self.log("test_loss", loss, batch_size=batch[self.input_key].shape[0])
         if batch[self.target_key].shape[0] > 1:

--- a/lightning_uq_box/uq_methods/sngp.py
+++ b/lightning_uq_box/uq_methods/sngp.py
@@ -53,6 +53,7 @@ class SNGPBase(BaseModule):
         coeff: float = 0.95,
         n_power_iterations: int = 1,
         input_size: Optional[int] = None,
+        freeze_backbone: bool = False,
         optimizer: OptimizerCallable = Adam,
         lr_scheduler: LRSchedulerCallable = None,
     ) -> None:
@@ -72,6 +73,7 @@ class SNGPBase(BaseModule):
                 should be (0, 1)
             n_power_iterations: number of power iterations for spectral normalization
             input_size: image dimension input size needed for spectral normalization
+            freeze_backbone: whether to freeze the feature extractor
             optimizer: Optimizer
             lr_scheduler: Learning rate scheduler
         """
@@ -96,6 +98,8 @@ class SNGPBase(BaseModule):
         self.normalize_gp_features = normalize_gp_features
         self.feature_scale = feature_scale
         self.ridge_penalty = ridge_penalty
+
+        self.freeze_backbone = freeze_backbone
 
         self._build_model()
 
@@ -130,6 +134,11 @@ class SNGPBase(BaseModule):
 
         self.recompute_covariance = True
         self.register_buffer("covariance", torch.eye(self.num_random_features))
+
+        # freeze feature extractor
+        if self.freeze_backbone:
+            for param in self.feature_extractor.parameters():
+                param.requires_grad = False
 
     def forward(self, x: Tensor) -> tuple[Tensor]:
         """Forward pass of the SNGP model.
@@ -343,6 +352,7 @@ class SNGPClassification(SNGPBase):
         input_size: Optional[int] = None,
         mean_field_factor: Optional[float] = math.pi / 8,
         task: str = "multiclass",
+        freeze_backbone: bool = False,
         optimizer: OptimizerCallable = Adam,
         lr_scheduler: LRSchedulerCallable = None,
     ) -> None:
@@ -363,7 +373,8 @@ class SNGPClassification(SNGPBase):
             n_power_iterations: number of power iterations for spectral normalization
             input_size: image dimension input size needed for spectral normalization
             mean_field_factor: Mean field factor, required for classification problems
-            task: classification task, one of ['binary', 'multiclass', 'multilabel']
+            task: classification task, one of ['binary', 'multiclass']
+            freeze_backbone: whether to freeze the feature extractor
             optimizer: Optimizer
             lr_scheduler: Learning rate scheduler
         """
@@ -382,6 +393,7 @@ class SNGPClassification(SNGPBase):
             coeff,
             n_power_iterations,
             input_size,
+            freeze_backbone,
             optimizer,
             lr_scheduler,
         )

--- a/lightning_uq_box/uq_methods/temp_scaling.py
+++ b/lightning_uq_box/uq_methods/temp_scaling.py
@@ -128,6 +128,7 @@ class TempScaling(PosthocBase):
             dataloader_idx: dataloader index
         """
         out_dict = self.predict_step(batch[self.input_key])
+        out_dict[self.target_key] = batch[self.target_key]
         self.test_metrics(out_dict["pred"], batch[self.target_key])
         out_dict = self.add_aux_data_to_dict(out_dict, batch)
         return out_dict

--- a/lightning_uq_box/uq_methods/temp_scaling.py
+++ b/lightning_uq_box/uq_methods/temp_scaling.py
@@ -127,9 +127,10 @@ class TempScaling(PosthocBase):
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
-        preds = self.predict_step(batch[self.input_key])
-        self.test_metrics(preds["pred"], batch[self.target_key])
-        return preds
+        out_dict = self.predict_step(batch[self.input_key])
+        self.test_metrics(out_dict["pred"], batch[self.target_key])
+        out_dict = self.add_aux_data_to_dict(out_dict, batch)
+        return out_dict
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -262,7 +262,9 @@ def save_classification_predictions(outputs: dict[str, Tensor], path: str) -> No
     for i in range(logits.shape[1]):
         outputs[f"logit_{i}"] = logits[:, i]
 
-    if "pred_set" in outputs:
+    pred_set_true = True if "pred_set" in outputs else False
+
+    if pred_set_true:
         pred_set = [
             str(tensor.cpu().numpy().tolist()) for tensor in outputs.pop("pred_set")
         ]
@@ -285,7 +287,7 @@ def save_classification_predictions(outputs: dict[str, Tensor], path: str) -> No
     # Concatenate the two DataFrames
     df = pd.concat([df_pred, df_outputs], axis=1)
 
-    if "pred_set" in outputs:
+    if pred_set_true:
         df = pd.concat([df, df_pred_set], axis=1)
 
     if os.path.exists(path):

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -437,3 +437,24 @@ def freeze_model_backbone(model: nn.Module) -> None:
         _, module = _get_output_layer_name_and_module(model)
         for param in module.parameters():
             param.requires_grad = True
+
+
+def freeze_segmentation_model(
+    model: nn.Module, freeze_backbone: bool, freeze_decoder: bool
+) -> None:
+    """Freeze the encoder or decoder of a segmentation model.
+
+    Args:
+        model: pytorch model
+        freeze_backbone: whether to freeze the model backbone
+        freeze_decoder: whether to freeze the decoder
+    """
+    # Freeze backbone
+    if hasattr(model, "encoder") and freeze_backbone:
+        for param in model.encoder.parameters():
+            param.requires_grad = False
+
+    # Freeze decoder
+    if hasattr(model, "decoder") and freeze_decoder:
+        for param in model.decoder.parameters():
+            param.requires_grad = False

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -317,6 +317,8 @@ def map_stochastic_modules(
     # remove duplicates due to weight/bias
     module_names = list(set(module_names))
 
+    module_names = [name for name in module_names if name != ""]  # remove empty string
+
     if not stochastic_module_names:  # None means fully stochastic
         part_stoch_names = module_names.copy()
     elif all(isinstance(elem, int) for elem in stochastic_module_names):
@@ -415,3 +417,23 @@ def _get_num_outputs(model: nn.Module) -> int:
     else:
         raise ValueError(f"Module {module} does not have out_features or out_channels.")
     return num_outputs
+
+
+def freeze_model_backbone(model: nn.Module) -> None:
+    """Freeze the backbone of a model.
+
+    Args:
+        model: pytorch model
+    """
+    for param in model.parameters():
+        param.requires_grad = False
+
+    # for timm model
+    if hasattr(model, "get_classifier"):
+        for param in model.get_classifier().parameters():
+            param.requires_grad = True
+    else:
+        # find last layer
+        _, module = _get_output_layer_name_and_module(model)
+        for param in module.parameters():
+            param.requires_grad = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,11 @@ dependencies = [
     # Uncertainty toolbox metrics
     "uncertainty-toolbox>=0.1.1",
     # Kornia for Test Time Augmentations and other image processing
-    "kornia>=0.6.9"
+    "kornia>=0.6.9",
     # timm models for image classification and regression
     "timm>=0.9.2",
     # torchseg for segmentation, pixelwise regression
-    "torchseg>=0.0.1a1",
+    "torchseg>=0.0.1a1"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ dependencies = [
     "uncertainty-toolbox>=0.1.1",
     # Kornia for Test Time Augmentations and other image processing
     "kornia>=0.6.9"
+    # timm models for image classification and regression
+    "timm>=0.9.2",
+    # torchseg for segmentation, pixelwise regression
+    "torchseg>=0.0.1a1",
 ]
 dynamic = ["version"]
 
@@ -77,11 +81,6 @@ dev = [
     "hydra-core>=1.3.2",
     # omegaconf
     "omegaconf>=2.3.0",
-    # timm usef for model config testing
-    "timm>=0.9.2",
-    # torchseg for segmentation models
-    "torchseg>=0.0.1a1",
-
 
     ### Docs ###
     # sphinx

--- a/tests/configs/image_classification/base.yaml
+++ b/tests/configs/image_classification/base.yaml
@@ -1,0 +1,16 @@
+model:
+  _target_: lightning_uq_box.uq_methods.DeterministicClassification
+  model:
+    _target_: timm.create_model
+    model_name: resnet18
+    num_classes: 4
+    drop_rate: 0.1
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 0.003
+  lr_scheduler:
+    _target_: torch.optim.lr_scheduler.ConstantLR
+    _partial_: true
+  loss_fn:
+    _target_: torch.nn.CrossEntropyLoss

--- a/tests/configs/image_regression/sngp.yaml
+++ b/tests/configs/image_regression/sngp.yaml
@@ -1,0 +1,15 @@
+model:
+  _target_: lightning_uq_box.uq_methods.SNGPRegression
+  feature_extractor:
+    _target_: timm.create_model
+    model_name: resnet18
+    num_classes: 8 # number of latent features
+    drop_rate: 0.1
+  lr_scheduler:
+    _target_: torch.optim.lr_scheduler.ConstantLR
+    _partial_: true
+  num_targets: 1
+  loss_fn:
+    _target_: torch.nn.CrossEntropyLoss
+  input_size: 64
+  

--- a/tests/configs/image_segmentation/base.yaml
+++ b/tests/configs/image_segmentation/base.yaml
@@ -1,5 +1,5 @@
 uq_method:
-  _target_: lightning_uq_box.uq_methods.ProbUNet
+  _target_: lightning_uq_box.uq_methods.DeterministicSegmentation
   model:
     _target_: torchseg.Unet
     encoder_name: resnet18
@@ -13,3 +13,5 @@ uq_method:
   lr_scheduler:
     _target_: torch.optim.lr_scheduler.ConstantLR
     _partial_: true
+  loss_fn:
+    _target_: torch.nn.CrossEntropyLoss

--- a/tests/configs/image_segmentation/bnn_vi_elbo.yaml
+++ b/tests/configs/image_segmentation/bnn_vi_elbo.yaml
@@ -1,4 +1,4 @@
-model:
+uq_method:
   _target_: lightning_uq_box.uq_methods.BNN_VI_ELBO_Segmentation
   model:
     _target_: torchseg.Unet

--- a/tests/configs/image_segmentation/bnn_vi_elbo_part_stoch.yaml
+++ b/tests/configs/image_segmentation/bnn_vi_elbo_part_stoch.yaml
@@ -1,4 +1,4 @@
-model:
+uq_method:
   _target_: lightning_uq_box.uq_methods.BNN_VI_ELBO_Segmentation
   model:
     _target_: torchseg.Unet

--- a/tests/configs/image_segmentation/hierarchical_prob_unet.yaml
+++ b/tests/configs/image_segmentation/hierarchical_prob_unet.yaml
@@ -1,4 +1,4 @@
-model:
+uq_method:
   _target_: lightning_uq_box.uq_methods.HierarchicalProbUNet
   optimizer:
     _target_: torch.optim.Adam

--- a/tests/configs/image_segmentation/mc_dropout.yaml
+++ b/tests/configs/image_segmentation/mc_dropout.yaml
@@ -1,4 +1,4 @@
-model:
+uq_method:
   _target_: lightning_uq_box.uq_methods.MCDropoutSegmentation
   model:
     _target_: torchseg.Unet

--- a/tests/configs/image_segmentation/swag.yaml
+++ b/tests/configs/image_segmentation/swag.yaml
@@ -1,4 +1,4 @@
-model:
+uq_method:
   _target_: lightning_uq_box.uq_methods.SWAGSegmentation
   model:
     _target_: torchseg.Unet

--- a/tests/uq_methods/test_classification.py
+++ b/tests/uq_methods/test_classification.py
@@ -66,6 +66,36 @@ class TestClassificationTask:
         )
 
 
+frozen_config_paths = [
+    "tests/configs/classification/mc_dropout.yaml",
+    "tests/configs/classification/bnn_vi_elbo.yaml",
+    "tests/configs/classification/dkl.yaml",
+    "tests/configs/classification/due.yaml",
+    "tests/configs/classification/sngp.yaml",
+]
+
+
+class TestFrozenBackbone:
+    @pytest.mark.parametrize("model_config_path", frozen_config_paths)
+    def test_freeze_backbone(self, model_config_path: str) -> None:
+        cli = get_uq_box_cli(
+            ["--config", model_config_path, "--model.freeze_backbone", "True"]
+        )
+        model = cli.model
+        try:
+            assert not all(
+                [param.requires_grad for param in model.model.model[0].parameters()]
+            )
+            assert all(
+                [param.requires_grad for param in model.model.model[-1].parameters()]
+            )
+        except AttributeError:
+            # check that entire feature extractor is frozen
+            assert not all(
+                [param.requires_grad for param in model.feature_extractor.parameters()]
+            )
+
+
 posthoc_config_paths = [
     "tests/configs/classification/temp_scaling.yaml",
     "tests/configs/classification/raps.yaml",

--- a/tests/uq_methods/test_image_classification.py
+++ b/tests/uq_methods/test_image_classification.py
@@ -86,6 +86,40 @@ class TestPosthoc:
         trainer.test(model, datamodule=datamodule)
 
 
+frozen_config_paths = [
+    "tests/configs/image_classification/mc_dropout.yaml",
+    "tests/configs/image_classification/bnn_vi_elbo.yaml",
+    "tests/configs/image_classification/due.yaml",
+    "tests/configs/image_classification/sngp.yaml",
+]
+
+
+class TestFrozenBackbone:
+    @pytest.mark.parametrize("model_name", ["resnet18", "vit_small_patch8_224"])
+    @pytest.mark.parametrize("model_config_path", frozen_config_paths)
+    def test_freeze_backbone(self, model_config_path: str, model_name: str) -> None:
+        model_conf = OmegaConf.load(model_config_path)
+
+        try:
+            model_conf.model.model.model_name = model_name
+            model = instantiate(model_conf.model, freeze_backbone=True)
+            assert not all([param.requires_grad for param in model.model.parameters()])
+            assert all(
+                [
+                    param.requires_grad
+                    for param in model.model.get_classifier().parameters()
+                ]
+            )
+        except AttributeError:
+            model_conf.model.feature_extractor.model_name = model_name
+            model_conf.model.input_size = 224
+            model = instantiate(model_conf.model, freeze_backbone=True)
+            # check that entire feature extractor is frozen
+            assert not all(
+                [param.requires_grad for param in model.feature_extractor.parameters()]
+            )
+
+
 ensemble_model_config_paths = ["tests/configs/image_classification/mc_dropout.yaml"]
 
 

--- a/tests/uq_methods/test_image_classification.py
+++ b/tests/uq_methods/test_image_classification.py
@@ -18,6 +18,7 @@ from lightning_uq_box.datamodules import ToyImageClassificationDatamodule
 from lightning_uq_box.uq_methods import DeepEnsembleClassification, TTAClassification
 
 model_config_paths = [
+    "tests/configs/image_classification/base.yaml",
     "tests/configs/image_classification/mc_dropout.yaml",
     "tests/configs/image_classification/bnn_vi_elbo.yaml",
     "tests/configs/image_classification/swag.yaml",
@@ -87,6 +88,7 @@ class TestPosthoc:
 
 
 frozen_config_paths = [
+    "tests/configs/image_classification/base.yaml",
     "tests/configs/image_classification/mc_dropout.yaml",
     "tests/configs/image_classification/bnn_vi_elbo.yaml",
     "tests/configs/image_classification/due.yaml",

--- a/tests/uq_methods/test_image_regression.py
+++ b/tests/uq_methods/test_image_regression.py
@@ -74,6 +74,7 @@ class TestImageRegressionTask:
 
 
 frozen_config_paths = [
+    "tests/configs/image_regression/mean_variance_estimation.yaml",
     "tests/configs/image_regression/mc_dropout_nll.yaml",
     "tests/configs/image_regression/bnn_vi_elbo.yaml",
     "tests/configs/image_regression/due.yaml",

--- a/tests/uq_methods/test_image_regression.py
+++ b/tests/uq_methods/test_image_regression.py
@@ -73,6 +73,40 @@ class TestImageRegressionTask:
         )
 
 
+frozen_config_paths = [
+    "tests/configs/image_regression/mc_dropout.yaml",
+    "tests/configs/image_regression/bnn_vi_elbo.yaml",
+    "tests/configs/image_regression/due.yaml",
+    "tests/configs/image_regression/sngp.yaml",
+]
+
+
+class TestFrozenBackbone:
+    @pytest.mark.parametrize("model_name", ["resnet18", "vit_small_patch8_224"])
+    @pytest.mark.parametrize("model_config_path", frozen_config_paths)
+    def test_freeze_backbone(self, model_config_path: str, model_name: str) -> None:
+        model_conf = OmegaConf.load(model_config_path)
+
+        try:
+            model_conf.model.model.model_name = model_name
+            model = instantiate(model_conf.model, freeze_backbone=True)
+            assert not all([param.requires_grad for param in model.model.parameters()])
+            assert all(
+                [
+                    param.requires_grad
+                    for param in model.model.get_classifier().parameters()
+                ]
+            )
+        except AttributeError:
+            model_conf.model.feature_extractor.model_name = model_name
+            model_conf.model.input_size = 224
+            model = instantiate(model_conf.model, freeze_backbone=True)
+            # check that entire feature extractor is frozen
+            assert not all(
+                [param.requires_grad for param in model.feature_extractor.parameters()]
+            )
+
+
 ensemble_model_config_paths = [
     "tests/configs/image_regression/mc_dropout_nll.yaml",
     "tests/configs/image_regression/mean_variance_estimation.yaml",

--- a/tests/uq_methods/test_image_regression.py
+++ b/tests/uq_methods/test_image_regression.py
@@ -74,7 +74,7 @@ class TestImageRegressionTask:
 
 
 frozen_config_paths = [
-    "tests/configs/image_regression/mc_dropout.yaml",
+    "tests/configs/image_regression/mc_dropout_nll.yaml",
     "tests/configs/image_regression/bnn_vi_elbo.yaml",
     "tests/configs/image_regression/due.yaml",
     "tests/configs/image_regression/sngp.yaml",

--- a/tests/uq_methods/test_image_segmentation.py
+++ b/tests/uq_methods/test_image_segmentation.py
@@ -20,6 +20,7 @@ from lightning_uq_box.uq_methods import DeepEnsembleSegmentation
 seed_everything(0)
 
 model_config_paths = [
+    "tests/configs/image_segmentation/base.yaml",
     "tests/configs/image_segmentation/bnn_vi_elbo.yaml",
     "tests/configs/image_segmentation/bnn_vi_elbo_part_stoch.yaml",
     "tests/configs/image_segmentation/mc_dropout.yaml",

--- a/tests/uq_methods/test_image_segmentation.py
+++ b/tests/uq_methods/test_image_segmentation.py
@@ -40,7 +40,7 @@ class TestImageClassificationTask:
         model_conf = OmegaConf.load(model_config_path)
         data_conf = OmegaConf.load(data_config_path)
 
-        model = instantiate(model_conf.model)
+        model = instantiate(model_conf.uq_method)
         datamodule = instantiate(data_conf.data)
         trainer = Trainer(
             max_epochs=2,
@@ -52,6 +52,53 @@ class TestImageClassificationTask:
 
         trainer.fit(model, datamodule)
         trainer.test(ckpt_path="best", datamodule=datamodule)
+
+
+frozen_config_paths = [
+    "tests/configs/image_segmentation/base.yaml",
+    "tests/configs/image_segmentation/mc_dropout.yaml",
+    "tests/configs/image_segmentation/bnn_vi_elbo.yaml",
+]
+
+
+class TestFrozenSegmentation:
+    @pytest.mark.parametrize("model_name", ["Unet", "DeepLabV3Plus"])
+    @pytest.mark.parametrize("backbone", ["resnet18", "mobilenet_v2"])
+    @pytest.mark.parametrize("model_config_path", frozen_config_paths)
+    def test_freeze_backbone(
+        self, model_config_path: str, model_name: str, backbone: str
+    ) -> None:
+        model_conf = OmegaConf.load(model_config_path)
+        model_conf.uq_method.model["_target_"] = f"torchseg.{model_name}"
+        model_conf.uq_method.model["encoder_name"] = backbone
+
+        module = instantiate(model_conf.uq_method, freeze_backbone=True)
+        seg_model = module.model
+
+        assert all(
+            [param.requires_grad is False for param in seg_model.encoder.parameters()]
+        )
+        assert all([param.requires_grad for param in seg_model.decoder.parameters()])
+        assert all(
+            [param.requires_grad for param in seg_model.segmentation_head.parameters()]
+        )
+
+    @pytest.mark.parametrize("model_name", ["Unet", "DeepLabV3Plus"])
+    @pytest.mark.parametrize("model_config_path", frozen_config_paths)
+    def test_freeze_decoder(self, model_config_path: str, model_name: str) -> None:
+        model_conf = OmegaConf.load(model_config_path)
+        model_conf.uq_method.model["_target_"] = f"torchseg.{model_name}"
+
+        module = instantiate(model_conf.uq_method, freeze_decoder=True)
+        seg_model = module.model
+
+        assert all(
+            [param.requires_grad is False for param in seg_model.decoder.parameters()]
+        )
+        assert all([param.requires_grad for param in seg_model.encoder.parameters()])
+        assert all(
+            [param.requires_grad for param in seg_model.segmentation_head.parameters()]
+        )
 
 
 ensemble_model_config_paths = ["tests/configs/image_segmentation/mc_dropout.yaml"]
@@ -74,7 +121,7 @@ class TestDeepEnsemble:
         for i in range(5):
             tmp_path = tmp_path_factory.mktemp(f"run_{i}")
 
-            model = instantiate(model_conf.model)
+            model = instantiate(model_conf.uq_method)
             datamodule = instantiate(data_conf.data)
             trainer = Trainer(
                 max_epochs=2, log_every_n_steps=1, default_root_dir=str(tmp_path)

--- a/tests/uq_methods/test_regression.py
+++ b/tests/uq_methods/test_regression.py
@@ -78,6 +78,37 @@ class TestRegressionTask:
         )
 
 
+frozen_config_paths = [
+    "tests/configs/regression/mc_dropout_nll.yaml",
+    "tests/configs/regression/bnn_vi_elbo.yaml",
+    "tests/configs/regression/dkl.yaml",
+    "tests/configs/regression/due.yaml",
+    "tests/configs/regression/sngp.yaml",
+    "tests/configs/regression/qr_model.yaml",
+]
+
+
+class TestFrozenBackbone:
+    @pytest.mark.parametrize("model_config_path", frozen_config_paths)
+    def test_freeze_backbone(self, model_config_path: str) -> None:
+        cli = get_uq_box_cli(
+            ["--config", model_config_path, "--model.freeze_backbone", "True"]
+        )
+        model = cli.model
+        try:
+            assert not all(
+                [param.requires_grad for param in model.model.model[0].parameters()]
+            )
+            assert all(
+                [param.requires_grad for param in model.model.model[-1].parameters()]
+            )
+        except AttributeError:
+            # check that entire feature extractor is frozen
+            assert not all(
+                [param.requires_grad for param in model.feature_extractor.parameters()]
+            )
+
+
 ensemble_model_config_paths = [
     "tests/configs/regression/mc_dropout_mse.yaml",
     "tests/configs/regression/mc_dropout_nll.yaml",


### PR DESCRIPTION
Inspired by torchgeo trainers, this PR adds the following enhancements:

- for classification and regression, one can specify to freeze the backbone, with a default implementation for all timm models and for custom models this would be last layer by default but can be overwritten
- for segmentation and pixel wise regression, encoder or decoder frozen with default for torchseg and can be overwritten