### PR TITLE
Delete extraneous isort config file

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[tool.isort]
-profile = "black"


### PR DESCRIPTION
This is already in pyproject.toml, no need to duplicate it