### PR TITLE
Pass alpha to metric computation

### DIFF
--- a/docs/tutorials/earth_observation/raps.ipynb
+++ b/docs/tutorials/earth_observation/raps.ipynb
@@ -1142,6 +1142,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ALPHA = 0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 78,
    "metadata": {},
    "outputs": [],
@@ -1152,8 +1161,8 @@
     "            num_classes=NUM_CLASSES, average=\"micro\", task=\"multiclass\"\n",
     "        ),\n",
     "        \"Calibration\": CalibrationError(num_classes=NUM_CLASSES, task=\"multiclass\"),\n",
-    "        \"Coverage\": EmpiricalCoverage(topk=None),\n",
-    "        \"SetSize\": SetSize(topk=None),\n",
+    "        \"Coverage\": EmpiricalCoverage(topk=None, alpha=ALPHA),\n",
+    "        \"SetSize\": SetSize(topk=None, alpha=ALPHA),\n",
     "    }\n",
     ")"
    ]
@@ -1263,7 +1272,7 @@
    ],
    "source": [
     "raps_dir = tempfile.mkdtemp()\n",
-    "raps = RAPS(model=base_model.model, alpha=0.1)\n",
+    "raps = RAPS(model=base_model.model, alpha=ALPHA)\n",
     "raps.input_key = \"image\"\n",
     "raps.target_key = \"label\"\n",
     "raps.test_metrics = metrics.clone(prefix=\"test_\")\n",


### PR DESCRIPTION
The alpha level should be passed to the metrics to reflect the chosen level.