### PR TITLE
Fix Mac Tests

### DIFF
--- a/tests/datamodules/test_datamodules.py
+++ b/tests/datamodules/test_datamodules.py
@@ -38,7 +38,9 @@ def test_deterministic_regression_on_toy_datasets(datamodule, tmp_path: Path):
     )
 
     # Initialize the trainer
-    trainer = Trainer(max_epochs=1, fast_dev_run=True, default_root_dir=tmp_path)
+    trainer = Trainer(
+        accelerator="cpu", max_epochs=1, fast_dev_run=True, default_root_dir=tmp_path
+    )
 
     # Fit and test
     trainer.fit(model, datamodule=data_module)

--- a/tests/uq_methods/test_classification.py
+++ b/tests/uq_methods/test_classification.py
@@ -187,6 +187,6 @@ class TestDeepEnsemble:
 
         datamodule = TwoMoonsDataModule()
 
-        trainer = Trainer(default_root_dir=str(tmp_path))
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
 
         trainer.test(ensemble_model, datamodule=datamodule)

--- a/tests/uq_methods/test_image_classification.py
+++ b/tests/uq_methods/test_image_classification.py
@@ -50,6 +50,7 @@ class TestImageClassificationTask:
         model = instantiate(model_conf.model)
         datamodule = instantiate(data_conf.data)
         trainer = Trainer(
+            accelerator="cpu",
             max_epochs=2,
             log_every_n_steps=1,
             default_root_dir=str(tmp_path),
@@ -81,7 +82,9 @@ class TestPosthoc:
 
         model = instantiate(model_conf.model)
         datamodule = instantiate(data_conf.data)
-        trainer = Trainer(default_root_dir=str(tmp_path), inference_mode=False)
+        trainer = Trainer(
+            accelerator="cpu", default_root_dir=str(tmp_path), inference_mode=False
+        )
         # use validation for testing, should be calibration loader for conformal
         trainer.validate(model, datamodule.val_dataloader())
         trainer.test(model, datamodule=datamodule)
@@ -145,7 +148,10 @@ class TestDeepEnsemble:
             model = instantiate(model_conf.model)
             datamodule = instantiate(data_conf.data)
             trainer = Trainer(
-                max_epochs=2, log_every_n_steps=1, default_root_dir=str(tmp_path)
+                accelerator="cpu",
+                max_epochs=2,
+                log_every_n_steps=1,
+                default_root_dir=str(tmp_path),
             )
             trainer.fit(model, datamodule)
             trainer.test(ckpt_path="best", datamodule=datamodule)
@@ -168,7 +174,7 @@ class TestDeepEnsemble:
 
         datamodule = ToyImageClassificationDatamodule()
 
-        trainer = Trainer(default_root_dir=str(tmp_path))
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
 
         trainer.test(ensemble_model, datamodule=datamodule)
 
@@ -190,6 +196,6 @@ class TestTTAModel:
         tta_model = TTAClassification(base_model, merge_strategy=merge_strategy)
         datamodule = ToyImageClassificationDatamodule()
 
-        trainer = Trainer(default_root_dir=str(tmp_path))
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
 
         trainer.test(tta_model, datamodule)

--- a/tests/uq_methods/test_image_regression.py
+++ b/tests/uq_methods/test_image_regression.py
@@ -55,6 +55,7 @@ class TestImageRegressionTask:
         model = instantiate(model_conf.uq_method)
         datamodule = instantiate(data_conf.data)
         trainer = Trainer(
+            accelerator="cpu",
             max_epochs=2,
             log_every_n_steps=1,
             default_root_dir=str(tmp_path),
@@ -136,7 +137,10 @@ class TestDeepEnsemble:
             model = instantiate(model_conf.uq_method)
             datamodule = instantiate(data_conf.data)
             trainer = Trainer(
-                max_epochs=2, log_every_n_steps=1, default_root_dir=str(tmp_path)
+                accelerator="cpu",
+                max_epochs=2,
+                log_every_n_steps=1,
+                default_root_dir=str(tmp_path),
             )
             trainer.fit(model, datamodule)
             trainer.test(ckpt_path="best", datamodule=datamodule)
@@ -157,7 +161,7 @@ class TestDeepEnsemble:
             len(ensemble_members_dict), ensemble_members_dict
         )
         datamodule = ToyImageRegressionDatamodule()
-        trainer = Trainer(default_root_dir=str(tmp_path))
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
         trainer.test(ensemble_model, datamodule=datamodule)
 
         # check that predictions are saved
@@ -184,6 +188,6 @@ class TestTTAModel:
         tta_model = TTARegression(base_model, merge_strategy=merge_strategy)
         datamodule = ToyImageRegressionDatamodule()
 
-        trainer = Trainer(default_root_dir=str(tmp_path))
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
 
         trainer.test(tta_model, datamodule)

--- a/tests/uq_methods/test_image_segmentation.py
+++ b/tests/uq_methods/test_image_segmentation.py
@@ -46,6 +46,7 @@ class TestImageClassificationTask:
         model = instantiate(model_conf.uq_method)
         datamodule = instantiate(data_conf.data)
         trainer = Trainer(
+            accelerator="cpu",
             max_epochs=2,
             log_every_n_steps=1,
             default_root_dir=str(tmp_path),
@@ -136,7 +137,10 @@ class TestDeepEnsemble:
             model = instantiate(model_conf.uq_method)
             datamodule = instantiate(data_conf.data)
             trainer = Trainer(
-                max_epochs=2, log_every_n_steps=1, default_root_dir=str(tmp_path)
+                accelerator="cpu",
+                max_epochs=2,
+                log_every_n_steps=1,
+                default_root_dir=str(tmp_path),
             )
             trainer.fit(model, datamodule)
             trainer.test(ckpt_path="best", datamodule=datamodule)
@@ -159,7 +163,7 @@ class TestDeepEnsemble:
 
         datamodule = ToySegmentationDataModule()
 
-        trainer = Trainer(default_root_dir=str(tmp_path))
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
 
         trainer.test(ensemble_model, datamodule=datamodule)
 

--- a/tests/uq_methods/test_pixelwise_regression.py
+++ b/tests/uq_methods/test_pixelwise_regression.py
@@ -170,7 +170,7 @@ class TestDeepEnsemble:
             len(ensemble_members_dict), ensemble_members_dict
         )
         datamodule = ToyPixelwiseRegressionDataModule()
-        trainer = Trainer(default_root_dir=str(tmp_path))
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
         trainer.test(ensemble_model, datamodule=datamodule)
 
         # check that predictions are saved

--- a/tests/uq_methods/test_pixelwise_regression.py
+++ b/tests/uq_methods/test_pixelwise_regression.py
@@ -47,6 +47,7 @@ class TestImageClassificationTask:
         model = instantiate(model_conf.uq_method)
         datamodule = instantiate(data_conf.data)
         trainer = Trainer(
+            accelerator="cpu",
             max_epochs=2,
             log_every_n_steps=1,
             default_root_dir=str(tmp_path),
@@ -145,7 +146,10 @@ class TestDeepEnsemble:
             model = instantiate(model_conf.uq_method)
             datamodule = instantiate(data_conf.data)
             trainer = Trainer(
-                max_epochs=2, log_every_n_steps=1, default_root_dir=str(tmp_path)
+                accelerator="cpu",
+                max_epochs=2,
+                log_every_n_steps=1,
+                default_root_dir=str(tmp_path),
             )
             trainer.fit(model, datamodule)
             trainer.test(ckpt_path="best", datamodule=datamodule)

--- a/tests/uq_methods/test_regression.py
+++ b/tests/uq_methods/test_regression.py
@@ -167,7 +167,7 @@ class TestDeepEnsemble:
 
         datamodule = ToyHeteroscedasticDatamodule()
 
-        trainer = Trainer(default_root_dir=str(tmp_path))
+        trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
 
         trainer.test(ensemble_model, datamodule=datamodule)
 


### PR DESCRIPTION
By default Lightning uses `auto` as a way to find accelerators, and for Mac it finds available devices that are not actually supported so set `Trainer(accelerator="cpu")` for running tests.