### PR TITLE
fix docs faliling with setuptools

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,3 +5,4 @@ sphinx_book_theme==1.1.2
 myst-parser==2.0.0
 sphinx-togglebutton==0.3.2
 ipykernel==6.29.3
+setuptools==69.5.1


### PR DESCRIPTION
Setuptools > 70.0 fails for building docs with `cannot import name 'packaging' from 'pkg_resources' (/home/docs/checkouts/readthedocs.org/user_builds/lightning-uq-box/envs/105/lib/python3.12/site-packages/pkg_resources/__init__.py)`, so this is a temporary fix