### PR TITLE
Separate test and docs dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,16 @@ To this end, each UQ-Method is essentially just a [Lightning Module](https://lig
 
 # Installation
 
+For the latest released version you can run, 
+
 ```console
-$ pip install lightning-uq-box
+pip install lightning-uq-box
+```
+
+For the latest development version you can run,
+
+```console
+pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git
 ```
 
 # UQ-Methods

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -18,12 +18,12 @@ We welcome contributions and suggestions to this open-source project. This could
 
 ## Tests
 
-Lightning-UQ-Box uses [Github Actions](https://docs.github.com/en/actions) as a Continuous Integration (CI) tool. This means that on every commit there is a set of unit tests that is being executed in order to check that the changes do not break the current version. All unit tests need to pass before the PR can be merged. Additionally, we check code coverage to make see how many lines of code are covered by the unit tests.
+Lightning-UQ-Box uses [Github Actions](https://docs.github.com/en/actions) as a Continuous Integration (CI) tool. This means that on every commit there is a set of unit tests that is being executed in order to check that the changes do not break the current version. All unit tests need to pass before the PR can be merged. Additionally, we check code coverage to make see how many lines of code are covered by the unit tests. To install the extra dependencies necessary for running tests you can run `pip install lightning-uq-box[tests]`.
 
 For example, if you have implemented a new feature or a new method and want to check the coverage of your unit tests, you can run the following command:
 
 ```console
-$ pytest --cov=lightning_uq_box/uq_methods --cov-report=term-missing tests/uq_methods/test_changed_method.py
+pytest --cov=lightning_uq_box/uq_methods --cov-report=term-missing tests/uq_methods/test_changed_method.py
 ```
 
 ## Linters
@@ -35,8 +35,8 @@ We use a linter to ensure a codebase that follows [PEP-8](https://peps.python.or
 You can apply these tools from the project root where the necessary configuration files are found. To test with ruff, you can do:
 
 ```console
-$ ruff check
-$ ruff format
+ruff check
+ruff format
 ```
 
 These tools should be used from the root of the project to ensure that our configuration files are found. Ruff is relatively easy to use, and will automatically fix most issues it encounters:
@@ -44,16 +44,16 @@ These tools should be used from the root of the project to ensure that our confi
 You can also use `git pre-commit hooks <https://pre-commit.com/>`_ to automatically apply these checks before each commit. You can use pre-commit as follows:
 
 ```console
-$ pip install pre-commit
-$ pre-commit install
-$ pre-commit run --all-files
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
 ```
 
 ## Documentation
 
-The documentation is hosted on [Read the Docs](https://readthedocs.org/). If you are making changes to the documentation, it can be useful to inspect the changes locally before committing them. You can follow these steps:
+The documentation is hosted on [Read the Docs](https://readthedocs.org/). If you are making changes to the documentation, it can be useful to inspect the changes locally before committing them. You can install the additionally required dependencies with `pip install lightning-uq-box[docs]`. Afterwards you can follow these steps:
 
-1. Move to the `docs` directory
+1. Navigate to the `docs` directory
 2. In the `conf.py` file look at the very last line and uncomment if you want to speed up the documentation build. This will not execute the notebooks and just build the rest of the documentation. However, when you are making changes to the notebooks as well, you should leave it uncommented as the notebooks won't be updated with your changes otherwise.
 3. Run `make clean` followed by `make html`
 4. Once that command finishes, there will be a `index.html` file under `docs/_build/html`. Paste the full path to that file into your web browser to inspect what the documentation would look like with your changes

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,13 @@ In the tables that follow below, you can see what UQ-Method/Task combination is 
 To get started, 
 
 ```console
-$ pip install lightning-uq-box
+pip install lightning-uq-box
+```
+
+For the latest development version you can run,
+
+```console
+pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git
 ```
 
 ## Classification of UQ-Methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,12 @@ dev = [
     "hydra-core>=1.3.2",
     # omegaconf
     "omegaconf>=2.3.0",
+    ## Style
+    # ruff 0.2+ required for [ruff.lint]
+    "ruff>=0.2", 
+]
 
+docs = [
     ### Docs ###
     # sphinx
     "sphinx>=4,<7",
@@ -101,10 +106,6 @@ dev = [
     "jupytext>=1.15.2",
     # ipykernel to run notebooks
     "ipykernel>=6.29.3",
-
-    ## Style
-    # ruff 0.2+ required for [ruff.lint]
-    "ruff>=0.2",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ dev = [
     "hydra-core>=1.3.2",
     # omegaconf
     "omegaconf>=2.3.0",
+    # jsonargparse
+    "jsonargparse[signatures]>=4.28.0",
     ## Style
     # ruff 0.2+ required for [ruff.lint]
     "ruff>=0.2", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = [
+tests = [
     ### Tests ###
     # pytest 7.3+ required for tmp_path_retention_policy
     "pytest>=7.3",


### PR DESCRIPTION
This PR separates the test and docs dependencies in the `pyproject.toml` file to make the installation more clear. Adresses comment in #143 .

Also aims to make some other installation commands more clear.