### PR TITLE
Remove n_ensemble_members in DeepEnsemble signatures

### DIFF
--- a/docs/tutorials/regression/deep_ensemble.ipynb
+++ b/docs/tutorials/regression/deep_ensemble.ipynb
@@ -213,7 +213,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "deep_ens_nll = DeepEnsembleRegression(n_ensembles, trained_models_nll)"
+    "deep_ens_nll = DeepEnsembleRegression(trained_models_nll)"
    ]
   },
   {

--- a/lightning_uq_box/uq_methods/deep_ensemble.py
+++ b/lightning_uq_box/uq_methods/deep_ensemble.py
@@ -46,9 +46,6 @@ class DeepEnsemble(BaseModule):
         """
         super().__init__()
         self.n_ensemble_members = len(ensemble_members)
-        # make hparams accessible
-        # TODO: do we still need it if we ignore the only parameter?
-        self.save_hyperparameters(ignore=["ensemble_members"])
         self.ensemble_members = ensemble_members
 
         self.setup_task()

--- a/lightning_uq_box/uq_methods/deep_ensemble.py
+++ b/lightning_uq_box/uq_methods/deep_ensemble.py
@@ -35,21 +35,20 @@ class DeepEnsemble(BaseModule):
 
     def __init__(
         self,
-        n_ensemble_members: int,
         ensemble_members: list[dict[str, type[LightningModule] | str]],
     ) -> None:
         """Initialize a new instance of DeepEnsembleModel Wrapper.
 
         Args:
-            n_ensemble_members: number of ensemble members
             ensemble_members: List of dicts where each element specifies the
                 LightningModule class and a path to a checkpoint
             save_dir: path to directory where to store prediction
             quantiles: quantile values to compute for prediction
         """
         super().__init__()
-        assert len(ensemble_members) == n_ensemble_members
+        self.n_ensemble_members = len(ensemble_members)
         # make hparams accessible
+        # TODO: do we still need it if we ignore the only parameter?
         self.save_hyperparameters(ignore=["ensemble_members"])
         self.ensemble_members = ensemble_members
 
@@ -177,7 +176,6 @@ class DeepEnsembleClassification(DeepEnsemble):
 
     def __init__(
         self,
-        n_ensemble_members: int,
         ensemble_members: list[dict[str, type[LightningModule] | str]],
         num_classes: int,
         task: str = "multiclass",
@@ -185,7 +183,6 @@ class DeepEnsembleClassification(DeepEnsemble):
         """Initialize a new instance of DeepEnsemble for Classification.
 
         Args:
-            n_ensemble_members: number of ensemble members
             ensemble_members: List of dicts where each element specifies the
                 LightningModule class and a path to a checkpoint
             num_classes: number of classes
@@ -194,7 +191,7 @@ class DeepEnsembleClassification(DeepEnsemble):
         assert task in self.valid_tasks
         self.task = task
         self.num_classes = num_classes
-        super().__init__(n_ensemble_members, ensemble_members)
+        super().__init__(ensemble_members)
 
     def setup_task(self) -> None:
         """Set up task for classification."""
@@ -247,7 +244,6 @@ class DeepEnsembleSegmentation(DeepEnsembleClassification):
 
     def __init__(
         self,
-        n_ensemble_members: int,
         ensemble_members: list[dict[str, type[LightningModule] | str]],
         num_classes: int,
         task: str = "multiclass",
@@ -256,14 +252,13 @@ class DeepEnsembleSegmentation(DeepEnsembleClassification):
         """Initialize a new instance of DeepEnsemble for Segmentation.
 
         Args:
-            n_ensemble_members: number of ensemble members
             ensemble_members: List of dicts where each element specifies the
                 LightningModule class and a path to a checkpoint
             num_classes: number of classes
             task: classification task, one of "multiclass", "binary" or "multilabel"
             save_preds: whether to save predictions
         """
-        super().__init__(n_ensemble_members, ensemble_members, num_classes, task)
+        super().__init__(ensemble_members, num_classes, task)
         self.save_preds = save_preds
 
     def setup_task(self) -> None:
@@ -325,19 +320,17 @@ class DeepEnsemblePxRegression(DeepEnsembleRegression):
 
     def __init__(
         self,
-        n_ensemble_members: int,
         ensemble_members: list[dict[str, type[LightningModule] | str]],
         save_preds: bool = False,
     ) -> None:
         """Initialize a new instance of DeepEnsemble for Pixelwise Regression.
 
         Args:
-            n_ensemble_members: number of ensemble members
             ensemble_members: List of dicts where each element specifies the
                 LightningModule class and a path to a checkpoint
             save_preds: whether to save predictions
         """
-        super().__init__(n_ensemble_members, ensemble_members)
+        super().__init__(ensemble_members)
         self.save_preds = save_preds
 
     pred_dir_name = "preds"

--- a/lightning_uq_box/uq_methods/deep_ensemble.py
+++ b/lightning_uq_box/uq_methods/deep_ensemble.py
@@ -34,8 +34,7 @@ class DeepEnsemble(BaseModule):
     """
 
     def __init__(
-        self,
-        ensemble_members: list[dict[str, type[LightningModule] | str]],
+        self, ensemble_members: list[dict[str, type[LightningModule] | str]]
     ) -> None:
         """Initialize a new instance of DeepEnsembleModel Wrapper.
 

--- a/tests/uq_methods/test_classification.py
+++ b/tests/uq_methods/test_classification.py
@@ -182,7 +182,7 @@ class TestDeepEnsemble:
     ) -> None:
         """Test Deep Ensemble."""
         ensemble_model = DeepEnsembleClassification(
-            len(ensemble_members_dict), ensemble_members_dict, 2
+            ensemble_members_dict, 2
         )
 
         datamodule = TwoMoonsDataModule()

--- a/tests/uq_methods/test_classification.py
+++ b/tests/uq_methods/test_classification.py
@@ -181,9 +181,7 @@ class TestDeepEnsemble:
         self, ensemble_members_dict: dict[str, Any], tmp_path: Path
     ) -> None:
         """Test Deep Ensemble."""
-        ensemble_model = DeepEnsembleClassification(
-            ensemble_members_dict, 2
-        )
+        ensemble_model = DeepEnsembleClassification(ensemble_members_dict, 2)
 
         datamodule = TwoMoonsDataModule()
 

--- a/tests/uq_methods/test_image_classification.py
+++ b/tests/uq_methods/test_image_classification.py
@@ -169,7 +169,7 @@ class TestDeepEnsemble:
     ) -> None:
         """Test Deep Ensemble."""
         ensemble_model = DeepEnsembleClassification(
-            len(ensemble_members_dict), ensemble_members_dict, num_classes=4
+            ensemble_members_dict, num_classes=4
         )
 
         datamodule = ToyImageClassificationDatamodule()

--- a/tests/uq_methods/test_image_regression.py
+++ b/tests/uq_methods/test_image_regression.py
@@ -158,9 +158,7 @@ class TestDeepEnsemble:
         self, ensemble_members_dict: dict[str, Any], tmp_path: Path
     ) -> None:
         """Test Deep Ensemble."""
-        ensemble_model = DeepEnsembleRegression(
-            ensemble_members_dict
-        )
+        ensemble_model = DeepEnsembleRegression(ensemble_members_dict)
         datamodule = ToyImageRegressionDatamodule()
         trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))
         trainer.test(ensemble_model, datamodule=datamodule)

--- a/tests/uq_methods/test_image_regression.py
+++ b/tests/uq_methods/test_image_regression.py
@@ -159,7 +159,7 @@ class TestDeepEnsemble:
     ) -> None:
         """Test Deep Ensemble."""
         ensemble_model = DeepEnsembleRegression(
-            len(ensemble_members_dict), ensemble_members_dict
+            ensemble_members_dict
         )
         datamodule = ToyImageRegressionDatamodule()
         trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))

--- a/tests/uq_methods/test_image_segmentation.py
+++ b/tests/uq_methods/test_image_segmentation.py
@@ -158,9 +158,7 @@ class TestDeepEnsemble:
     ) -> None:
         """Test Deep Ensemble."""
         ensemble_model = DeepEnsembleSegmentation(
-            ensemble_members_dict,
-            num_classes=4,
-            save_preds=True,
+            ensemble_members_dict, num_classes=4, save_preds=True
         )
 
         datamodule = ToySegmentationDataModule()

--- a/tests/uq_methods/test_image_segmentation.py
+++ b/tests/uq_methods/test_image_segmentation.py
@@ -158,7 +158,6 @@ class TestDeepEnsemble:
     ) -> None:
         """Test Deep Ensemble."""
         ensemble_model = DeepEnsembleSegmentation(
-            len(ensemble_members_dict),
             ensemble_members_dict,
             num_classes=4,
             save_preds=True,

--- a/tests/uq_methods/test_pixelwise_regression.py
+++ b/tests/uq_methods/test_pixelwise_regression.py
@@ -167,7 +167,7 @@ class TestDeepEnsemble:
     ) -> None:
         """Test Deep Ensemble."""
         ensemble_model = DeepEnsemblePxRegression(
-            len(ensemble_members_dict), ensemble_members_dict, save_preds=True
+            ensemble_members_dict, save_preds=True
         )
         datamodule = ToyPixelwiseRegressionDataModule()
         trainer = Trainer(accelerator="cpu", default_root_dir=str(tmp_path))

--- a/tests/uq_methods/test_regression.py
+++ b/tests/uq_methods/test_regression.py
@@ -161,9 +161,7 @@ class TestDeepEnsemble:
         self, ensemble_members_dict: dict[str, Any], tmp_path: Path
     ) -> None:
         """Test Deep Ensemble."""
-        ensemble_model = DeepEnsembleRegression(
-            ensemble_members_dict
-        )
+        ensemble_model = DeepEnsembleRegression(ensemble_members_dict)
 
         datamodule = ToyHeteroscedasticDatamodule()
 

--- a/tests/uq_methods/test_regression.py
+++ b/tests/uq_methods/test_regression.py
@@ -162,7 +162,7 @@ class TestDeepEnsemble:
     ) -> None:
         """Test Deep Ensemble."""
         ensemble_model = DeepEnsembleRegression(
-            len(ensemble_members_dict), ensemble_members_dict
+            ensemble_members_dict
         )
 
         datamodule = ToyHeteroscedasticDatamodule()


### PR DESCRIPTION
Closes #149 

This removes the redundance of having to pass a list of ensemble members and their length to the constructor of all classes derived from `DeepEnsemble`.