### PR TITLE
Deep Ensemble Eval Mode Fix

### DIFF
--- a/lightning_uq_box/uq_methods/deep_ensemble.py
+++ b/lightning_uq_box/uq_methods/deep_ensemble.py
@@ -70,7 +70,7 @@ class DeepEnsemble(BaseModule):
             model_config["base_model"].load_state_dict(
                 torch.load(model_config["ckpt_path"])["state_dict"]
             )
-            model_config["base_model"].to(X.device)
+            model_config["base_model"].to(X.device).eval()
             out.append(model_config["base_model"](X))
         return torch.stack(out, dim=-1)
 
@@ -132,7 +132,7 @@ class DeepEnsembleRegression(DeepEnsemble):
         """Compute prediction step for a deep ensemble.
 
         Args:
-            X: input tensor of shape [batch_size, input_di]
+            X: input tensor of shape [batch_size, input_dims]
             batch_idx: the index of this batch
             dataloader_idx: the index of the dataloader
 
@@ -142,7 +142,9 @@ class DeepEnsembleRegression(DeepEnsemble):
         with torch.no_grad():
             preds = self.generate_ensemble_predictions(X)
 
-        return process_regression_prediction(preds)
+        pred_dict = process_regression_prediction(preds)
+        pred_dict["samples"] = preds
+        return pred_dict
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -201,7 +203,7 @@ class DeepEnsembleClassification(DeepEnsemble):
         """Compute prediction step for a deep ensemble.
 
         Args:
-            X: input tensor of shape [batch_size, input_di]
+            X: input tensor of shape [batch_size, input_dims]
             batch_idx: the index of this batch
             dataloader_idx: the index of the dataloader
 

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -264,7 +264,11 @@ def save_regression_predictions(outputs: dict[str, Tensor], path: str) -> None:
     if "samples" in outputs:
         samples = outputs.pop("samples")
         for i in range(samples.shape[-1]):
-            cpu_outputs[f"sample_{i}"] = samples[..., i].squeeze(-1).cpu().numpy()
+            sample = samples[..., i].squeeze(-1).cpu().numpy()
+            # mve prediction
+            if sample.ndim == 2 and sample.shape[-1] == 2:
+                sample = sample[:, 0]
+            cpu_outputs[f"sample_{i}"] = sample
 
     for key, val in outputs.items():
         if isinstance(val, Tensor):

--- a/tests/uq_methods/test_deep_ensemble.py
+++ b/tests/uq_methods/test_deep_ensemble.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Test Deep Ensemble."""
+
+import glob
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+from hydra.utils import instantiate
+from lightning import Trainer
+from omegaconf import OmegaConf
+from pytest import TempPathFactory
+
+from lightning_uq_box.datamodules import ToyImageRegressionDatamodule
+from lightning_uq_box.uq_methods import DeepEnsembleRegression
+
+data_config_paths = ["tests/configs/image_regression/toy_image_regression.yaml"]
+
+ensemble_model_config_paths = [
+    "tests/configs/image_regression/mc_dropout_nll.yaml",
+    "tests/configs/image_regression/mean_variance_estimation.yaml",
+]
+
+
+class TestDeepEnsemble:
+    @pytest.fixture(
+        params=[
+            (model_config_path, data_config_path)
+            for model_config_path in ensemble_model_config_paths
+            for data_config_path in data_config_paths
+        ]
+    )
+    def ensemble_members_dict(self, request, tmp_path_factory: TempPathFactory) -> None:
+        model_config_path, data_config_path = request.param
+        model_conf = OmegaConf.load(model_config_path)
+        data_conf = OmegaConf.load(data_config_path)
+        # train networks for deep ensembles
+        ckpt_paths = []
+        for i in range(3):
+            tmp_path = tmp_path_factory.mktemp(f"run_{i}")
+
+            model = instantiate(model_conf.uq_method)
+            datamodule = instantiate(data_conf.data)
+            trainer = Trainer(
+                accelerator="cpu",
+                max_epochs=2,
+                log_every_n_steps=1,
+                default_root_dir=str(tmp_path),
+            )
+            trainer.fit(model, datamodule)
+            trainer.test(ckpt_path="best", datamodule=datamodule)
+
+            # Find the .ckpt file in the lightning_logs directory
+            ckpt_file = glob.glob(
+                f"{str(tmp_path)}/lightning_logs/version_*/checkpoints/*.ckpt"
+            )[0]
+            ckpt_paths.append({"base_model": model, "ckpt_path": ckpt_file})
+
+        return ckpt_paths
+
+    def test_deep_ensemble(
+        self, ensemble_members_dict: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """Test Deep Ensemble."""
+        ensemble_model = DeepEnsembleRegression(ensemble_members_dict)
+        datamodule = ToyImageRegressionDatamodule()
+        batch = next(iter(datamodule.test_dataloader()))
+
+        pred = ensemble_model.predict_step(batch["input"])
+
+        # check that prediction under ensemble are the same as the individual ones
+        for i in range(len(ensemble_members_dict)):
+            with torch.no_grad():
+                assert torch.allclose(
+                    pred["samples"][..., i],
+                    ensemble_members_dict[i]["base_model"](batch["input"]),
+                )


### PR DESCRIPTION
This PR fixes a bug, where loaded pretrained weights were not correctly put into eval mode. This therefore effects model predictions with architectures that have `BatchNorm` or `Dropout` layers. This flew under the radar, as we tested/reproduced Toy examples with simple MLP architectures or simple Conv models that did not contain such layers. There is now an explicit test to check that the underlying individual model predictions and the ones yielded by the ensemble are the same.