### PR TITLE
pip install from main in tutorials

### DIFF
--- a/docs/tutorials/classification/bnn_vi_elbo.ipynb
+++ b/docs/tutorials/classification/bnn_vi_elbo.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/card.ipynb
+++ b/docs/tutorials/classification/card.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/deterministic.ipynb
+++ b/docs/tutorials/classification/deterministic.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/dkl.ipynb
+++ b/docs/tutorials/classification/dkl.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/laplace.ipynb
+++ b/docs/tutorials/classification/laplace.ipynb
@@ -15,7 +15,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/masksembles.ipynb
+++ b/docs/tutorials/classification/masksembles.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/mc_dropout.ipynb
+++ b/docs/tutorials/classification/mc_dropout.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/sngp.ipynb
+++ b/docs/tutorials/classification/sngp.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/swag.ipynb
+++ b/docs/tutorials/classification/swag.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/classification/vae_mnist.ipynb
+++ b/docs/tutorials/classification/vae_mnist.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/earth_observation/raps.ipynb
+++ b/docs/tutorials/earth_observation/raps.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install lightning-uq-box\n",
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git\n",
     "%pip install torchgeo\n",
     "%pip install --upgrade --no-cache-dir gdown rarfile"
    ]

--- a/docs/tutorials/regression/bnn_vi.ipynb
+++ b/docs/tutorials/regression/bnn_vi.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/bnn_vi_elbo.ipynb
+++ b/docs/tutorials/regression/bnn_vi_elbo.ipynb
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/bnn_vi_lv.ipynb
+++ b/docs/tutorials/regression/bnn_vi_lv.ipynb
@@ -83,7 +83,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/card.ipynb
+++ b/docs/tutorials/regression/card.ipynb
@@ -30,7 +30,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/conformal_qr.ipynb
+++ b/docs/tutorials/regression/conformal_qr.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/deep_ensemble.ipynb
+++ b/docs/tutorials/regression/deep_ensemble.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/deep_evidential_regression.ipynb
+++ b/docs/tutorials/regression/deep_evidential_regression.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/deep_kernel_learning.ipynb
+++ b/docs/tutorials/regression/deep_kernel_learning.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/density_layer.ipynb
+++ b/docs/tutorials/regression/density_layer.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/gp.ipynb
+++ b/docs/tutorials/regression/gp.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/laplace.ipynb
+++ b/docs/tutorials/regression/laplace.ipynb
@@ -15,7 +15,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/masksemble_nll.ipynb
+++ b/docs/tutorials/regression/masksemble_nll.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/mc_dropout.ipynb
+++ b/docs/tutorials/regression/mc_dropout.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/mean_variance_estimation.ipynb
+++ b/docs/tutorials/regression/mean_variance_estimation.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/mixture_density.ipynb
+++ b/docs/tutorials/regression/mixture_density.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/quantile_regression.ipynb
+++ b/docs/tutorials/regression/quantile_regression.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/sngp.ipynb
+++ b/docs/tutorials/regression/sngp.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/swag.ipynb
+++ b/docs/tutorials/regression/swag.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box"
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git"
    ]
   },
   {

--- a/docs/tutorials/regression/vbll.ipynb
+++ b/docs/tutorials/regression/vbll.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box\n",
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git\n",
     "%pip install vbll"
    ]
   },

--- a/docs/tutorials/regression/vbll_sngp.ipynb
+++ b/docs/tutorials/regression/vbll_sngp.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "%pip install lightning-uq-box\n",
+    "%pip install git+https://github.com/lightning-uq-box/lightning-uq-box.git\n",
     "%pip install vbll"
    ]
   },


### PR DESCRIPTION
Closes #184 .

Currently, the notebooks run only an install from main, meaning that they only support the `stable` version of the docs, however, as we are making changes, and displaying the latest docs, they need to align with the main branch to not throw errors.