### PR TITLE
Add EMA support for CARD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,9 @@ dependencies = [
     # torchseg for segmentation, pixelwise regression
     "torchseg>=0.0.1a1",
     # saving pixelwise and segmentation predictions
-    "h5py==3.11.0"
+    "h5py==3.11.0",
+    # exponential moving average for pytorch models
+    "ema-pytorch>=0.7.0"
 ]
 dynamic = ["version"]
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -13,3 +13,4 @@ uncertainty-toolbox==0.1.1
 kornia==0.7.1
 h5py==3.11.0
 laplace-torch==0.2.1
+ema-pytorch==0.7.0


### PR DESCRIPTION
Closes #186 by adding EMA support for the CARDS model implementation. This also adds a dependency on `ema-pytorch` [package](https://github.com/lucidrains/ema-pytorch).

@wrkhard I hope this is what you were looking for. By default, the `ema` model is used during validation and prediction based on a boolean class attribute `self.use_ema_model`. Let me know if this is helpful and also other feedback you have about using the CARD implementation!