### PR TITLE
Codecov: silence PR comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+comment: false
+github_checks:
+  annotations: false


### PR DESCRIPTION
The PR comments are annoying. We can already see code coverage in the CI checks. Codecov also has an excellent browser extension: https://docs.codecov.com/docs/the-codecov-browser-extension