### PR TITLE
Models: fix type hints

### DIFF
--- a/lightning_uq_box/models/bnn_layers/base_variational.py
+++ b/lightning_uq_box/models/bnn_layers/base_variational.py
@@ -414,7 +414,9 @@ class BaseConvLayer_(BaseVariationalLayer_):
             out = outputs + perturbed_outputs
         return out
 
-    def apply_convolution(self, x: Tensor, weight: Tensor, bias: Tensor) -> Tensor:
+    def apply_convolution(
+        self, x: Tensor, weight: Tensor, bias: Tensor | None
+    ) -> Tensor:
         """Apply convolution."""
         return self.conv_function(
             x,
@@ -525,7 +527,9 @@ class BaseTransposeConvLayer_(BaseConvLayer_):
 
         super().init_parameters()
 
-    def apply_convolution(self, x: Tensor, weight: Tensor, bias: Tensor) -> Tensor:
+    def apply_convolution(
+        self, x: Tensor, weight: Tensor, bias: Tensor | None
+    ) -> Tensor:
         """Apply convolution."""
         return self.conv_function(
             x,

--- a/lightning_uq_box/models/bnn_layers/base_variational.py
+++ b/lightning_uq_box/models/bnn_layers/base_variational.py
@@ -374,8 +374,8 @@ class BaseConvLayer_(BaseVariationalLayer_):
         # compute delta_weight
         delta_weight = sigma_weight * eps_weight
 
-        bias = torch.tensor(0.0)
-        delta_bias = torch.tensor(0.0)
+        bias = None
+        delta_bias = None
         if self.bias:
             if self.is_frozen:
                 eps_bias = self.eps_bias

--- a/lightning_uq_box/models/bnn_layers/base_variational.py
+++ b/lightning_uq_box/models/bnn_layers/base_variational.py
@@ -374,8 +374,8 @@ class BaseConvLayer_(BaseVariationalLayer_):
         # compute delta_weight
         delta_weight = sigma_weight * eps_weight
 
-        bias = None
-        delta_bias = None
+        bias = torch.tensor(0)
+        delta_bias = torch.tensor(0)
         if self.bias:
             if self.is_frozen:
                 eps_bias = self.eps_bias

--- a/lightning_uq_box/models/bnn_layers/base_variational.py
+++ b/lightning_uq_box/models/bnn_layers/base_variational.py
@@ -374,8 +374,8 @@ class BaseConvLayer_(BaseVariationalLayer_):
         # compute delta_weight
         delta_weight = sigma_weight * eps_weight
 
-        bias = torch.tensor(0)
-        delta_bias = torch.tensor(0)
+        bias = torch.tensor(0.0)
+        delta_bias = torch.tensor(0.0)
         if self.bias:
             if self.is_frozen:
                 eps_bias = self.eps_bias

--- a/lightning_uq_box/models/bnn_layers/bnn_utils.py
+++ b/lightning_uq_box/models/bnn_layers/bnn_utils.py
@@ -115,19 +115,19 @@ def convert_deterministic_to_bnn(
         target_layer_name = layer_names[-1]
         current_layer = dict(current_module.named_children())[target_layer_name]
 
-        if "Conv" in current_layer.__class__.__name__:
+        if isinstance(current_layer, nn.Conv1d | nn.Conv2d | nn.Conv3d):
             setattr(
                 current_module,
                 target_layer_name,
                 bnn_conv_layer(bnn_prior_parameters, current_layer),
             )
-        elif "Linear" in current_layer.__class__.__name__:
+        elif isinstance(current_layer, nn.Linear):
             setattr(
                 current_module,
                 target_layer_name,
                 bnn_linear_layer(bnn_prior_parameters, current_layer),
             )
-        elif "LSTM" in current_layer.__class__.__name__:
+        elif isinstance(current_layer, nn.LSTM):
             setattr(
                 current_module,
                 target_layer_name,
@@ -153,6 +153,7 @@ def get_kl_loss(model: nn.Module) -> Tensor:
                 kl_loss = layer.kl_loss()
             else:
                 kl_loss += layer.kl_loss()
+    assert kl_loss
     return kl_loss
 
 

--- a/lightning_uq_box/models/bnn_layers/bnn_utils.py
+++ b/lightning_uq_box/models/bnn_layers/bnn_utils.py
@@ -153,7 +153,7 @@ def get_kl_loss(model: nn.Module) -> Tensor:
                 kl_loss = layer.kl_loss()
             else:
                 kl_loss += layer.kl_loss()
-    assert kl_loss
+    assert kl_loss is not None
     return kl_loss
 
 

--- a/lightning_uq_box/models/bnn_layers/linear_variational.py
+++ b/lightning_uq_box/models/bnn_layers/linear_variational.py
@@ -209,7 +209,7 @@ class LinearVariational(BaseVariationalLayer_):
             output = output.squeeze(0)
         return output
 
-    def sample_weights(self, n_samples: int) -> tuple[Tensor]:
+    def sample_weights(self, n_samples: int) -> tuple[Tensor, Tensor]:
         """Sample variational weights for batched sampling.
 
         Args:

--- a/lightning_uq_box/models/bnn_layers/rnn_layer.py
+++ b/lightning_uq_box/models/bnn_layers/rnn_layer.py
@@ -166,8 +166,8 @@ class LSTMVariational(BaseVariationalLayer_):
         """
         batch_size, seq_size, _ = X.size()
 
-        hidden_seq = []
-        c_ts = []
+        hidden_seq_list = []
+        c_ts_list = []
 
         if hidden_states is None:
             h_t, c_t = (
@@ -197,11 +197,11 @@ class LSTMVariational(BaseVariationalLayer_):
             c_t = f_t * c_t + i_t * g_t
             h_t = o_t * torch.tanh(c_t)
 
-            hidden_seq.append(h_t.unsqueeze(0))
-            c_ts.append(c_t.unsqueeze(0))
+            hidden_seq_list.append(h_t.unsqueeze(0))
+            c_ts_list.append(c_t.unsqueeze(0))
 
-        hidden_seq = torch.cat(hidden_seq, dim=0)
-        c_ts = torch.cat(c_ts, dim=0)
+        hidden_seq = torch.cat(hidden_seq_list, dim=0)
+        c_ts = torch.cat(c_ts_list, dim=0)
         # reshape from shape (sequence, batch, feature) to (batch, sequence, feature)
         hidden_seq = hidden_seq.transpose(0, 1).contiguous()
         c_ts = c_ts.transpose(0, 1).contiguous()

--- a/lightning_uq_box/models/bnnlv/latent_variable_network.py
+++ b/lightning_uq_box/models/bnnlv/latent_variable_network.py
@@ -88,9 +88,9 @@ class LatentVariableNetwork(nn.Module):
 
         self.z_mu = torch.tensor(0.0)
 
-        self.log_f_hat_z = None
-        self.log_normalizer_z = None
-        self.weight_eps = None
+        self.log_f_hat_z: Tensor | None = None
+        self.log_normalizer_z: Tensor | None = None
+        self.weight_eps: Tensor | None = None
 
     def fix_randomness(self) -> None:
         """Fix the randomness of reparameterization trick."""

--- a/lightning_uq_box/models/bnnlv/utils.py
+++ b/lightning_uq_box/models/bnnlv/utils.py
@@ -95,7 +95,7 @@ def replace_module(model: nn.Module, module_name: str, new_module: nn.Module) ->
 
 
 def retrieve_module_init_args(
-    current_module: type[nn.Module],
+    current_module: nn.Module,
 ) -> dict[str, str | float | int | bool]:
     """Reinitialize a new layer with arguments.
 
@@ -105,7 +105,7 @@ def retrieve_module_init_args(
     Returns:
         nn.Modules init args
     """
-    current_init_arg_names = list(inspect.signature(current_module.__init__).parameters)
+    current_init_arg_names = list(inspect.signature(current_module.__init__).parameters)  # type: ignore[misc]
     current_args: dict[str, str | float | int | bool] = {}
     for name in current_init_arg_names:
         if name == "bias":

--- a/lightning_uq_box/models/cards.py
+++ b/lightning_uq_box/models/cards.py
@@ -47,7 +47,7 @@ class ConditionalLinear(nn.Module):
 class DiffusionSequential(nn.Sequential):
     """My Sequential to accept multiple inputs."""
 
-    def forward(self, input: Tensor, t: Tensor):
+    def forward(self, input: Tensor, t: Tensor) -> Tensor:  # type: ignore[override]
         """Forward pass.
 
         Args:

--- a/lightning_uq_box/models/density_layers.py
+++ b/lightning_uq_box/models/density_layers.py
@@ -151,7 +151,7 @@ class DensityConv2d(DensityLayerBase_):
         self,
         in_channels: int,
         out_channels: int,
-        kernel_size: tuple[int],
+        kernel_size: tuple[int, int],
         stride: int,
         padding: int = 0,
         bias: bool = True,

--- a/lightning_uq_box/models/fc_resnet.py
+++ b/lightning_uq_box/models/fc_resnet.py
@@ -5,6 +5,8 @@
 
 """Fully Connected ResNet architecture."""
 
+from collections.abc import Callable
+
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
@@ -24,7 +26,7 @@ class FCResNet(nn.Module):
         features: int,
         depth: int,
         dropout_rate: float = 0.01,
-        num_outputs: int = None,
+        num_outputs: int | None = None,
         activation: str = "relu",
     ):
         """Initialze a new instance of the FCResNet.
@@ -52,7 +54,7 @@ class FCResNet(nn.Module):
             self.last = nn.Linear(features, num_outputs)
 
         if activation == "relu":
-            self.activation = F.relu
+            self.activation: Callable = F.relu
         elif activation == "elu":
             self.activation = F.elu
         else:

--- a/lightning_uq_box/models/hierarchical_prob_unet.py
+++ b/lightning_uq_box/models/hierarchical_prob_unet.py
@@ -22,6 +22,7 @@
 """Model Parts for Hierarchical Probabilistic U-Net."""
 
 from collections.abc import Callable
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -76,7 +77,7 @@ class _HierarchicalCore(nn.Module):
 
     def forward(
         self, inputs: Tensor, mean: bool | list[bool] = False, z_q: Tensor | None = None
-    ) -> dict[str, Tensor | list[Tensor]]:
+    ) -> dict[str, Any]:
         """Forward pass through the HierarchicalCore.
 
         Args:
@@ -327,6 +328,8 @@ def resize_down(input_features: Tensor, scale: int = 2) -> Tensor:
 
 class MovingAverage(nn.Module):
     """Moving Average Compute Module."""
+
+    average: Tensor
 
     def __init__(self, decay: float = 0.99, differentiable=False):
         """Initialize the MovingAverage.

--- a/lightning_uq_box/models/masked_conv.py
+++ b/lightning_uq_box/models/masked_conv.py
@@ -48,7 +48,7 @@ def conv_mask(width: int, height: int, include_center: bool = False) -> torch.Te
     )
 
 
-def weight_mask(in_channels: int, kernel_size: tuple[int]) -> torch.Tensor:
+def weight_mask(in_channels: int, kernel_size: tuple[int, int]) -> torch.Tensor:
     """Generate a weight mask for a given number of input channels and kernel size.
 
     Args:
@@ -74,7 +74,7 @@ class MaskedConv2d(nn.Module):
     def __init__(
         self,
         in_channels: int,
-        kernel_size: tuple[int] | int,
+        kernel_size: tuple[int, int] | int,
         stride: int = 1,
         padding: int = 0,
     ) -> None:

--- a/lightning_uq_box/models/masked_ensemble/masked_layers.py
+++ b/lightning_uq_box/models/masked_ensemble/masked_layers.py
@@ -89,15 +89,15 @@ def generate_masks_(m: int, num_masks: int, s: float) -> Tensor:
         A tensor containing the generated binary masks.
     """
     total_positions = int(m * s)
-    masks = []
+    masks_list = []
 
     for _ in range(num_masks):
         new_vector = torch.zeros(total_positions)
         idx = torch.randperm(total_positions)[:m]
         new_vector[idx] = 1
-        masks.append(new_vector)
+        masks_list.append(new_vector)
 
-    masks = torch.stack(masks)
+    masks = torch.stack(masks_list)
     # drop useless positions
     masks = masks[:, ~(masks == 0).all(dim=0)]
     return masks

--- a/lightning_uq_box/models/masked_ensemble/utils.py
+++ b/lightning_uq_box/models/masked_ensemble/utils.py
@@ -23,44 +23,41 @@ def convert_deterministic_to_masked_ensemble(
             the interval [1, 6].
     """
     for name, value in list(deterministic_model._modules.items()):
-        if deterministic_model._modules[name]._modules:
+        assert value
+        if value._modules:
             convert_deterministic_to_masked_ensemble(
-                deterministic_model._modules[name],
-                num_estimators=num_estimators,
-                scale=scale,
+                value, num_estimators=num_estimators, scale=scale
             )
-        elif "Conv2d" in deterministic_model._modules[name].__class__.__name__:
-            curr_layer = deterministic_model._modules[name]
-            if curr_layer.in_channels >= 10:
+        elif isinstance(value, nn.Conv2d):
+            if value.in_channels >= 10:
                 setattr(
                     deterministic_model,
                     name,
                     MaskedConv2d(
                         num_estimators=num_estimators,
                         scale=scale,
-                        in_channels=curr_layer.in_channels,
-                        out_channels=curr_layer.out_channels,
-                        kernel_size=curr_layer.kernel_size,
-                        stride=curr_layer.stride,
-                        padding=curr_layer.padding,
-                        dilation=curr_layer.dilation,
-                        groups=curr_layer.groups,
-                        bias=curr_layer.bias is not None,
+                        in_channels=value.in_channels,
+                        out_channels=value.out_channels,
+                        kernel_size=value.kernel_size,  # type: ignore[arg-type]
+                        stride=value.stride,  # type: ignore[arg-type]
+                        padding=value.padding,  # type: ignore[arg-type]
+                        dilation=value.dilation,  # type: ignore[arg-type]
+                        groups=value.groups,
+                        bias=value.bias is not None,
                     ),
                 )
 
-        elif "Linear" in deterministic_model._modules[name].__class__.__name__:
-            curr_layer = deterministic_model._modules[name]
-            if curr_layer.in_features >= 10:
+        elif isinstance(value, nn.Linear):
+            if value.in_features >= 10:
                 setattr(
                     deterministic_model,
                     name,
                     MaskedLinear(
                         num_estimators=num_estimators,
                         scale=scale,
-                        in_features=curr_layer.in_features,
-                        out_features=curr_layer.out_features,
-                        bias=curr_layer.bias is not None,
+                        in_features=value.in_features,
+                        out_features=value.out_features,
+                        bias=value.bias is not None,
                     ),
                 )
         else:

--- a/lightning_uq_box/models/masked_ensemble/utils.py
+++ b/lightning_uq_box/models/masked_ensemble/utils.py
@@ -23,7 +23,7 @@ def convert_deterministic_to_masked_ensemble(
             the interval [1, 6].
     """
     for name, value in list(deterministic_model._modules.items()):
-        assert value
+        assert value is not None
         if value._modules:
             convert_deterministic_to_masked_ensemble(
                 value, num_estimators=num_estimators, scale=scale

--- a/lightning_uq_box/models/mixture_density.py
+++ b/lightning_uq_box/models/mixture_density.py
@@ -85,7 +85,7 @@ class MixtureDensityLayer(nn.Module):
         if self.noise_type == "isotropic_clusters":
             sigma = torch.exp(sigma + eps).repeat(1, self.n_components * self.dim_out)
         if self.noise_type == "fixed":
-            assert self.fixed_noise_level
+            assert self.fixed_noise_level is not None
             sigma = torch.full_like(mu, fill_value=self.fixed_noise_level)
         mu = mu.reshape(-1, self.n_components, self.dim_out)
         sigma = sigma.reshape(-1, self.n_components, self.dim_out)

--- a/lightning_uq_box/models/mixture_density.py
+++ b/lightning_uq_box/models/mixture_density.py
@@ -63,7 +63,7 @@ class MixtureDensityLayer(nn.Module):
             n_outputs=n_components * dim_out + num_sigma_channels,
         )
 
-    def forward(self, x: Tensor, eps=1e-6) -> tuple[Tensor]:
+    def forward(self, x: Tensor, eps=1e-6) -> tuple[Tensor, Tensor, Tensor]:
         """Forward pass of MDN network.
 
         Args:
@@ -85,6 +85,7 @@ class MixtureDensityLayer(nn.Module):
         if self.noise_type == "isotropic_clusters":
             sigma = torch.exp(sigma + eps).repeat(1, self.n_components * self.dim_out)
         if self.noise_type == "fixed":
+            assert self.fixed_noise_level
             sigma = torch.full_like(mu, fill_value=self.fixed_noise_level)
         mu = mu.reshape(-1, self.n_components, self.dim_out)
         sigma = sigma.reshape(-1, self.n_components, self.dim_out)

--- a/lightning_uq_box/models/prob_unet.py
+++ b/lightning_uq_box/models/prob_unet.py
@@ -109,6 +109,7 @@ class Encoder(nn.Module):
             self.input_channels += 1
 
         layers: list[nn.Module] = []
+        output_dim = 0
         for i in range(len(self.num_filters)):
             """
             Determine input_dim and output_dim of conv layers in this block.

--- a/lightning_uq_box/models/prob_unet.py
+++ b/lightning_uq_box/models/prob_unet.py
@@ -319,4 +319,3 @@ class Fcomb(nn.Module):
         feature_map = torch.cat((feature_map, z), dim=self.channel_axis)
         output = self.layers(feature_map)
         return self.last_layer(output)
-

--- a/lightning_uq_box/models/prob_unet.py
+++ b/lightning_uq_box/models/prob_unet.py
@@ -55,7 +55,7 @@ def init_weights(m: nn.Module) -> None:
     """
     if isinstance(m, nn.Conv2d) or isinstance(m, nn.ConvTranspose2d):
         nn.init.kaiming_normal_(m.weight, mode="fan_in", nonlinearity="relu")
-        assert m.bias
+        assert m.bias is not None
         truncated_normal_(m.bias, mean=0, std=0.001)
 
 
@@ -67,7 +67,7 @@ def init_weights_orthogonal_normal(m: nn.Module) -> None:
     """
     if isinstance(m, nn.Conv2d) or isinstance(m, nn.ConvTranspose2d):
         nn.init.orthogonal_(m.weight)
-        assert m.bias
+        assert m.bias is not None
         truncated_normal_(m.bias, mean=0, std=0.001)
         # nn.init.normal_(m.bias, std=0.001)
 
@@ -196,7 +196,7 @@ class AxisAlignedConvGaussian(nn.Module):
         nn.init.kaiming_normal_(
             self.conv_layer.weight, mode="fan_in", nonlinearity="relu"
         )
-        assert self.conv_layer.bias
+        assert self.conv_layer.bias is not None
         nn.init.normal_(self.conv_layer.bias)
 
     def forward(self, input: Tensor, segm: Tensor | None = None) -> Independent:

--- a/lightning_uq_box/models/prob_unet.py
+++ b/lightning_uq_box/models/prob_unet.py
@@ -115,8 +115,8 @@ class Encoder(nn.Module):
             The first layer is input x output,
             All the subsequent layers are output x output.
             """
-            output_dim = num_filters[i]
             input_dim = self.input_channels if i == 0 else output_dim
+            output_dim = num_filters[i]
 
             if i != 0:
                 layers.append(

--- a/lightning_uq_box/models/prob_unet.py
+++ b/lightning_uq_box/models/prob_unet.py
@@ -187,11 +187,11 @@ class AxisAlignedConvGaussian(nn.Module):
         self.conv_layer = nn.Conv2d(
             num_filters[-1], 2 * self.latent_dim, (1, 1), stride=1
         )
-        self.show_img = torch.tensor(0)
-        self.show_seg = torch.tensor(0)
-        self.show_concat = torch.tensor(0)
-        self.show_enc = torch.tensor(0)
-        self.sum_input = torch.tensor(0)
+        self.show_img = torch.tensor(0.0)
+        self.show_seg = torch.tensor(0.0)
+        self.show_concat = torch.tensor(0.0)
+        self.show_enc = torch.tensor(0.0)
+        self.sum_input = torch.tensor(0.0)
 
         nn.init.kaiming_normal_(
             self.conv_layer.weight, mode="fan_in", nonlinearity="relu"

--- a/lightning_uq_box/models/vae.py
+++ b/lightning_uq_box/models/vae.py
@@ -3,6 +3,8 @@
 
 """Adapted from torchseg: https://github.com/isaaccorley/torchseg/blob/main/torchseg/decoders/unet/decoder.py."""
 
+from collections.abc import Sequence
+
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
@@ -18,7 +20,7 @@ class DecoderBlock(nn.Module):
         in_channels: int,
         out_channels: int,
         use_batchnorm: bool = True,
-        attention_type=None,
+        attention_type: bool | None = None,
     ):
         """Initialize the Decoder Block.
 
@@ -66,9 +68,9 @@ class VAEDecoder(nn.Module):
 
     def __init__(
         self,
-        decoder_channels: int,
+        decoder_channels: Sequence[int],
         use_batchnorm: bool = True,
-        attention_type: bool = None,
+        attention_type: bool | None = None,
     ):
         """Initialize the VAE Decoder.
 
@@ -85,9 +87,8 @@ class VAEDecoder(nn.Module):
         dec_out_channels = list(decoder_channels[1:])
 
         # combine decoder keyword arguments
-        kwargs = dict(use_batchnorm=use_batchnorm, attention_type=attention_type)
         blocks = [
-            DecoderBlock(in_ch, out_ch, **kwargs)
+            DecoderBlock(in_ch, out_ch, use_batchnorm, attention_type)
             for in_ch, out_ch in zip(dec_in_channels, dec_out_channels)
         ]
         blocks.append(


### PR DESCRIPTION
Was stuck on a bus and got bored. This PR fixes all model-related type hints. There are now only ~500 remaining mypy warnings for the `uq_methods` directory to resolve.

As always, I'm barely aware of what the code is doing for these, so a close look during review would be appreciated.