### PR TITLE
Fix typo in running_experiments config.yaml

### DIFF
--- a/docs/running_experiments.md
+++ b/docs/running_experiments.md
@@ -17,9 +17,9 @@ model: # model is the keyword for the lightning cli
       init_args:
         n_outputs: 10
         n_hidden: [50]
+    n_inducing_points: 10
     num_targets: 1
     gp_kernel: "RBF"
-    batch_size: int = 16: 10
     optimizer:
       class_path: torch.optim.Adam
       init_args:


### PR DESCRIPTION
Fixes a bug reported by Yesong Wei.

Honestly, we should consider replacing this file with something we can unit test to prevent this from happening again. See https://torchgeo.readthedocs.io/en/latest/tutorials/cli.html for an example of what this might look like.

I also encountered other issues when trying to run this file, such as:
```
INFO:root:Asdfghjkl backend not available since the old asdfghjkl dependency is not installed. If you want to use it, run: pip install git+https://git@github.com/wiseodd/asdl@asdfghjkl
```
and
```
RuntimeError: Tensor for argument weight is on cpu but expected on mps
```
TL;DR: need more testing