### PR TITLE
jsonargparse/omegaconf are required dependencies for the CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "matplotlib>=3.5",
     # numpy 1.21.1+ required by Python 3.10 wheels
     "numpy>=1.21.1",
+    # omegaconf
+    "omegaconf>=2.3.0",
     # pandas 1.1.3+ required for Python 3.10 wheels
     "pandas>=1.1.3",
     # torch 1.12+ required by torchvision
@@ -80,8 +82,6 @@ tests = [
     "pytest-lazy-fixture>=0.6",
     # hydra-core
     "hydra-core>=1.3.2",
-    # omegaconf
-    "omegaconf>=2.3.0",
     # jsonargparse
     "jsonargparse[signatures]>=4.28.0",
     ## Style

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ classifiers = [
 dependencies = [
     # einops 0.3+ required for einops.repeat
     "einops>=0.3",
+    # jsonargparse
+    "jsonargparse[signatures]>=4.28.0",
     # lightning 2+ required for LightningCLI args + sys.argv support
     "lightning>=2.4.0",
     # matplotlib 3.5 required for Python 3.10 wheels
@@ -82,8 +84,6 @@ tests = [
     "pytest-lazy-fixture>=0.6",
     # hydra-core
     "hydra-core>=1.3.2",
-    # jsonargparse
-    "jsonargparse[signatures]>=4.28.0",
     ## Style
     # ruff 0.9+ required for 2025 style guide
     "ruff>=0.9",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,7 @@
 setuptools==75.8.0
 
 # install
+jsonargparse[signatures]==4.35.0
 omegaconf==2.3.0
 torch==2.5.1
 torchmetrics==1.6.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,7 @@
 setuptools==75.8.0
 
 # install
+omegaconf==2.3.0
 torch==2.5.1
 torchmetrics==1.6.1
 torchvision==0.20.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,7 +4,6 @@ pytest==8.3.4
 nbmake==1.5.5
 pytest-cov==6.0.0
 hydra-core==1.3.2
-omegaconf==2.3.0
 timm==0.9.16
 jsonargparse[signatures]==4.35.0
 torchseg==0.0.1a4

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,6 @@ nbmake==1.5.5
 pytest-cov==6.0.0
 hydra-core==1.3.2
 timm==0.9.16
-jsonargparse[signatures]==4.35.0
 torchseg==0.0.1a4
 h5py==3.12.1
 vbll==0.2.6


### PR DESCRIPTION
Fixes a bug reported by Yesong Wei.

Omegaconf is a required dependency of the CLI, it isn't only used for testing.