### PR TITLE
Fix matplotlib get_cmap removal and lightning 2.6 checkpoint loading

### DIFF
--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -10,6 +10,7 @@ import torch
 import torch.nn as nn
 from lightning import LightningModule
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+from omegaconf import OmegaConf
 from torch import Tensor
 
 from .utils import (
@@ -44,6 +45,24 @@ class BaseModule(LightningModule):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize a new instance of the Base Module."""
         super().__init__(*args, **kwargs)
+
+    def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        """Convert OmegaConf hyperparameters to plain Python containers.
+
+        Since lightning 2.6, checkpoints are loaded with ``weights_only=True``,
+        which cannot unpickle OmegaConf containers. Configs instantiated from
+        yaml files pass arguments like list of module names as ``ListConfig``,
+        so convert them before they are written to the checkpoint.
+
+        Args:
+            checkpoint: the checkpoint dictionary that will be saved
+        """
+        hparams = checkpoint.get("hyper_parameters")
+        if hparams:
+            checkpoint["hyper_parameters"] = {
+                key: OmegaConf.to_object(value) if OmegaConf.is_config(value) else value
+                for key, value in hparams.items()
+            }
 
     @property
     def num_input_features(self) -> int:

--- a/lightning_uq_box/viz_utils/visualization_tools.py
+++ b/lightning_uq_box/viz_utils/visualization_tools.py
@@ -103,7 +103,7 @@ def plot_predictions_classification(
     num_cols = 3 if pred_uct is not None else 2
 
     fig, axs = plt.subplots(1, num_cols, figsize=(num_cols * 6, 6))
-    cm = plt.cm.get_cmap("plasma")
+    cm = plt.get_cmap("plasma")
 
     grid_size = int(np.sqrt(test_grid_points.shape[0]))
     xx = test_grid_points[:, 0].reshape(grid_size, grid_size)


### PR DESCRIPTION
Two independent fixes that together unblock CI and the open dependency bumps.

### matplotlib `get_cmap` (fixes #469)

`plt.cm.get_cmap` was removed from matplotlib. Since matplotlib is not pinned in `requirements/requirements.txt`, this silently broke `plot_predictions_classification` and now fails `tests/viz_utils/test_viz_utils.py` on **every** open PR, which is what is currently blocking the dependabot bumps rather than the bumps themselves.

Replaced with `plt.get_cmap("plasma")`, which is available across the supported matplotlib range, so no `hasattr` fallback is needed.

### lightning 2.6 checkpoint loading (unblocks #462)

lightning 2.6 loads checkpoints with `weights_only=True`, and the safe unpickler rejects OmegaConf containers:

```
_pickle.UnpicklingError: Weights only load failed.
WeightsUnpickler error: Unsupported global: GLOBAL omegaconf.listconfig.ListConfig
```

Hyperparameters instantiated from yaml configs arrive as `ListConfig` (e.g. `stochastic_module_names`), get stored by `save_hyperparameters`, and then cannot be read back. This failed `trainer.test(ckpt_path="best")` for SWAG and BNN_VI_ELBO segmentation.

`BaseModule.on_save_checkpoint` now converts OmegaConf containers to plain Python before they are written, so checkpoints stay loadable under `weights_only=True` without callers having to pass `weights_only=False`.

### Verification

Run locally against **lightning 2.6.1** with the rest of the pinned requirements:

- before: 2 failed (segmentation checkpoint loading), 2 failed (viz), 400 passed
- after: **404 passed**
- `ruff check`, `ruff format --check`, and `mypy --follow-imports=skip --exclude lightning_uq_box/uq_methods .` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbZPqzWkPueAKFunENDbSX