### PR TITLE
Fix currentmodule directive typo in uq_methods API docs

### DIFF
--- a/docs/api/uq_methods.rst
+++ b/docs/api/uq_methods.rst
@@ -77,7 +77,7 @@ Zig Zag Classification
 Mixture Density Networks
 ------------------------
 
-.. currentmodules:: lightning_uq_box.uq_methods.mixture_density
+.. currentmodule:: lightning_uq_box.uq_methods.mixture_density
 
 Mixture Density Regression
 ``````````````````````````


### PR DESCRIPTION
`docs/api/uq_methods.rst:80` spelled the directive `currentmodules` instead of `currentmodule`. Sphinx does not know that directive name, so it emits `ERROR: Unknown directive type "currentmodules"` and ignores it — leaving the current module set to `zigzag` from the section above. Autodoc then tries `zigzag.MDNRegression`, fails to import it, and the Mixture Density Regression API page renders empty.

Both errors show up in every readthedocs build; they are non-fatal only because `fail_on_warning` is commented out in `.readthedocs.yaml`. Every other `currentmodule` in the file is spelled correctly, so this is an isolated typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbZPqzWkPueAKFunENDbSX