### PR TITLE
Support Python 3.12-3.14

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -21,3 +21,6 @@ updates:
         update-types: ['version-update:semver-patch']
       # segmentation-models-pytorch pins timm, must update in unison
       - dependency-name: 'timm'
+      # curvlinops 3 broke laplace-torch, which is unmaintained
+      # https://github.com/aleximmer/Laplace/issues/285
+      - dependency-name: 'curvlinops-for-pytorch'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,9 +46,9 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          python-version: '3.10'
+          python-version: '3.13'
         - os: ubuntu-latest
-          python-version: '3.11'
+          python-version: '3.14'
         - os: macos-latest
           python-version: '3.12'
         - os: windows-latest

--- a/lightning_uq_box/datamodules/toy_due.py
+++ b/lightning_uq_box/datamodules/toy_due.py
@@ -73,10 +73,9 @@ class ToyDUE(LightningDataModule):
             random_state=split_seed,
         )
 
-        self.X_gtext = np.linspace(-10, 10, 500)
-        self.Y_gtext = np.cos(W * self.X_gtext + b).sum(0)
-        self.X_gtext = self.X_gtext.reshape(-1, 1)
-        self.Y_gtext = self.Y_gtext.reshape(-1, 1)
+        x_gtext = np.linspace(-10, 10, 500)
+        self.X_gtext = x_gtext.reshape(-1, 1)
+        self.Y_gtext = np.cos(W * x_gtext + b).sum(0).reshape(-1, 1)
 
         scalers = dict(
             X=StandardScaler().fit(self.X_train), Y=StandardScaler().fit(self.Y_train)

--- a/lightning_uq_box/datamodules/toy_half_moons.py
+++ b/lightning_uq_box/datamodules/toy_half_moons.py
@@ -54,6 +54,8 @@ class TwoMoonsDataModule(LightningDataModule):
         # Create a grid of test points
         x_min, x_max = min_x0 - 1, max_x0 + 1
         y_min, y_max = min_x1 - 1, max_x1 + 1
+        xx: np.ndarray
+        yy: np.ndarray
         xx, yy = np.meshgrid(
             np.linspace(x_min, x_max, 100), np.linspace(y_min, y_max, 100)
         )

--- a/lightning_uq_box/datamodules/toy_heteroscedastic.py
+++ b/lightning_uq_box/datamodules/toy_heteroscedastic.py
@@ -144,7 +144,7 @@ class ToyHeteroscedasticDatamodule(LightningDataModule):
         )
 
         # Ground truth for plotting (x,y) and prediction (x)
-        xmin, xmax = self.X_all.min(), self.X_all.max()
+        xmin, xmax = float(self.X_all.min()), float(self.X_all.max())
         span = xmax - xmin
         self.X_gtext = np.linspace(
             xmin - span * 0.1, xmax + span * 0.1, int(n_points * 1.5)

--- a/lightning_uq_box/models/masked_conv.py
+++ b/lightning_uq_box/models/masked_conv.py
@@ -24,6 +24,8 @@ def causal_mask(
     Returns:
         A tensor representing the causal mask.
     """
+    row_grid: np.ndarray
+    col_grid: np.ndarray
     row_grid, col_grid = np.meshgrid(np.arange(width), np.arange(height), indexing="ij")
     mask = np.logical_or(
         row_grid < starting_point[0],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 name = "lightning-uq-box"
 description = "Lightning-UQ-Box: A toolbox for uncertainty quantification in deep learning"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {file = "LICENSE"}
 authors = [
     {name = "Nils Lehmann", email = "n.lehmann@tum.de"},
@@ -26,9 +26,9 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
@@ -38,14 +38,14 @@ dependencies = [
     "jsonargparse[signatures]>=4.28.0",
     # lightning 2+ required for LightningCLI args + sys.argv support
     "lightning>=2.4.0",
-    # matplotlib 3.5 required for Python 3.10 wheels
-    "matplotlib>=3.5",
-    # numpy 1.21.1+ required by Python 3.10 wheels
-    "numpy>=1.21.1",
+    # matplotlib 3.7.3 required for Python 3.12 wheels
+    "matplotlib>=3.7.3",
+    # numpy 1.26+ required by Python 3.12 wheels
+    "numpy>=1.26",
     # omegaconf
     "omegaconf>=2.3.0",
-    # pandas 1.1.3+ required for Python 3.10 wheels
-    "pandas>=1.1.3",
+    # pandas 2.1.1+ required for Python 3.12 wheels
+    "pandas>=2.1.1",
     # torch 1.12+ required by torchvision
     "torch>=2.0",
     # torchmetrics 0.10+ required for binary/multiclass/multilabel classification metrics
@@ -58,8 +58,12 @@ dependencies = [
     "gpytorch>=1.11",
     # Laplace Approximation
     "laplace-torch>=0.2.1",
-    # curvlinops need to be fixed: https://github.com/aleximmer/Laplace/issues/285
-    "curvlinops-for-pytorch==2.0.1",
+    # curvlinops 2.0.1 caps numpy<2, which has no Python 3.12+ wheels, and
+    # curvlinops 3 dropped APIs laplace-torch still uses (KFACLinearOperator
+    # ._compute_kfac, curvlinops._base._LinearOperator). laplace-torch is
+    # unmaintained, so 2.0.0 is the only version that satisfies both.
+    # https://github.com/aleximmer/Laplace/issues/285
+    "curvlinops-for-pytorch==2.0.0",
     # Uncertainty toolbox metrics
     "uncertainty-toolbox>=0.1.1",
     # Kornia for Test Time Augmentations and other image processing

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,5 +15,5 @@ uncertainty-toolbox==0.1.1
 kornia==0.8.2
 h5py==3.15.1
 laplace-torch==0.2.2.2
-curvlinops-for-pytorch==2.0.1
+curvlinops-for-pytorch==2.0.0
 ema-pytorch==0.7.7


### PR DESCRIPTION
Moves the supported range to Python 3.12, 3.13 and 3.14.

## Why 3.10 and 3.11 go

scikit-learn 1.8+ and pandas 3.0+ declare `Requires-Python >=3.11`, so #457 and #464 fail all three 3.10 jobs at the pip step before a single test runs:

```
ERROR: Ignored the following versions that require a different python version:
  1.8.0 Requires-Python >=3.11; 1.9.0 Requires-Python >=3.11
ERROR: No matching distribution found for scikit-learn==1.9.0
```

## The curvlinops downgrade

Going past 3.12 means numpy 2, since numpy 1.x ends at 1.26.4 and has no cp313 wheels. That runs into `curvlinops-for-pytorch==2.0.1`, which caps `numpy<2.0.0`.

Upgrading is not the way out. curvlinops 3 removed APIs that laplace-torch still uses, and laplace-torch has had no release since November 2024 and no commit since April 2025:

- `from curvlinops._base import _LinearOperator` -> `ModuleNotFoundError` (aleximmer/Laplace#287 proposes a rename fix)
- with that rename applied, all 7 Laplace tests still fail on `AttributeError: 'KFACLinearOperator' object has no attribute '_compute_kfac'`

So the symbol rename in the open upstream PR is not sufficient; making curvlinops 3 work needs real porting inside laplace that nobody is doing. **curvlinops 2.0.0** predates both the numpy cap (added in 2.0.1) and the API removals, and is the only version satisfying both constraints. Dependabot is told to ignore it so it does not keep reopening this.

## Changes

- `requires-python` `>=3.10` -> `>=3.12`; classifiers now 3.12/3.13/3.14
- `tests.yaml` matrix `['3.10','3.11','3.12']` -> `['3.12','3.13','3.14']`
- `curvlinops-for-pytorch` `==2.0.1` -> `==2.0.0`, with the reasoning in a comment
- dependabot ignores `curvlinops-for-pytorch`
- the three floors whose comments read "required for Python 3.10 wheels" lifted to the earliest releases with cp312 wheels: matplotlib 3.5 -> 3.7.3, numpy 1.21.1 -> 1.26, pandas 1.1.3 -> 2.1.1

## Verification

Full suite run locally in clean conda envs with numpy 2.5.2:

| Python | result |
|---|---|
| 3.13.15 | 404 passed |
| 3.14.7 | 404 passed |

(Both initially showed one failure, the numpy 2 bug fixed separately in #478, now on main.)

## Branch protection

`pytest (ubuntu-latest, 3.10)`, `pytest (macos-latest, 3.10)`, `pytest (windows-latest, 3.10)` and the three 3.11 equivalents are required status checks on `main`. Once the matrix stops producing them they never report, so this PR and every other open PR will sit blocked until those contexts are removed and the new 3.13/3.14 ones added.

Unblocks #457 and #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbZPqzWkPueAKFunENDbSX