### PR TITLE
Fix ToyHeteroscedasticDatamodule inverse problem under numpy 2

### DIFF
--- a/lightning_uq_box/datamodules/toy_heteroscedastic.py
+++ b/lightning_uq_box/datamodules/toy_heteroscedastic.py
@@ -178,8 +178,8 @@ class ToyHeteroscedasticDatamodule(LightningDataModule):
             # handle the extended line separately
             self.X_gtext = self._n2t(
                 np.linspace(
-                    self.Y_all.min() - span * 0.1,
-                    self.Y_all.max() + span * 0.1,
+                    self.Y_all.min().item() - span * 0.1,
+                    self.Y_all.max().item() + span * 0.1,
                     int(n_points * 1.5),
                 )[:, None]
             )


### PR DESCRIPTION
`ToyHeteroscedasticDatamodule(invert=True)` raises on numpy 2:

```
ValueError: Does not validate against any of the Union subtypes
  - expected np.ndarray (got Tensor)
```

By the time the `invert` branch runs, the loop above has already converted `Y_all` to a torch `Tensor` via `_n2t`. numpy 1 coerced the 0-d tensor operands and returned an `ndarray`; numpy 2 dispatches `np.linspace` through the tensor's `__array_wrap__` and returns a `Tensor`, so `_n2t` calls `torch.from_numpy` on a `Tensor` and raises. The corresponding numpy 2 deprecation warning shows up in the same run:

```
DeprecationWarning: __array_wrap__ must accept context and return_scalar
arguments (positionally) in the future. (Deprecated NumPy 2.0)
```

Taking the scalars with `.item()` keeps `np.linspace` on plain floats.

This is user-visible today: `pyproject.toml` declares `numpy>=1.21.1` with no upper bound, so a fresh install resolves numpy 2 and hits this. It is currently masked in CI only because `curvlinops-for-pytorch==2.0.1` caps `numpy<2.0.0`.

Verified on Python 3.13 with numpy 2.5.2: the failing config (`tests/configs/regression/mixture_density.yaml`) passes, and the full suite goes from 403 passed / 1 failed to all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbZPqzWkPueAKFunENDbSX