### PR TITLE
fix(docs): restore Read the Docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,9 +31,9 @@ extensions = [
 
 myst_enable_extensions = ["dollarmath", "colon_fence"]
 master_doc = "index"
-# list of source suffix to include .py for jupytext
-source_suffix = [".rst", ".md", ".py"]
-# source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
+# Explicitly map source file types.  Treating Python files as reStructuredText makes
+# Sphinx try to parse this configuration file (and any helper scripts) as docs.
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
 templates_path = ["_templates"]
 
 # this is needed for jupytext
@@ -86,7 +86,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
-    "torch": ("https://pytorch.org/docs/stable", None),
+    "torch": ("https://docs.pytorch.org/docs/stable", None),
 }
 
 # some notebooks require GPU

--- a/lightning_uq_box/uq_methods/masked_ensemble.py
+++ b/lightning_uq_box/uq_methods/masked_ensemble.py
@@ -106,13 +106,13 @@ class MasksemblesBase(BaseModule):
         )
 
     def forward(self, x: Tensor):
-        """Forward pass.
+        r"""Forward pass.
 
         Args:
-            x: Input tensor of shape [batch_size, *input_shape]
+            x: Input tensor of shape [batch_size, \*input_shape]
 
         Returns:
-            Output tensor of shape [batch_size * num_estimators, *output_shape]
+            Output tensor of shape [batch_size \* num_estimators, \*output_shape]
         """
         # repeat the input tensor for each estimator
         x = repeat(x, "b ... -> (n b) ...", n=self.num_estimators)
@@ -277,13 +277,13 @@ class MasksemblesRegression(MasksemblesBase):
         self.test_metrics = default_regression_metrics("test")
 
     def predict_step(self, x: Tensor) -> Tensor:
-        """Predict the output of the model.
+        r"""Predict the output of the model.
 
         Args:
-            x: Input tensor of shape [batch_size, *input_shape]
+            x: Input tensor of shape [batch_size, \*input_shape]
 
         Returns:
-            Output tensor of shape [batch_size, *output_shape]
+            Output tensor of shape [batch_size, \*output_shape]
         """
         with torch.no_grad():
             ensemble_pred = self.forward(x)
@@ -384,13 +384,13 @@ class MasksemblesClassification(MasksemblesBase):
         return out
 
     def predict_step(self, x: Tensor) -> Tensor:
-        """Predict the output of the model.
+        r"""Predict the output of the model.
 
         Args:
-            x: Input tensor of shape [batch_size, *input_shape]
+            x: Input tensor of shape [batch_size, \*input_shape]
 
         Returns:
-            Output tensor of shape [batch_size, *output_shape]
+            Output tensor of shape [batch_size, \*output_shape]
         """
         with torch.no_grad():
             ensemble_pred = self.forward(x)


### PR DESCRIPTION
## Summary
- prevent Sphinx from parsing Python files as reStructuredText
- correct the Mixture Density API directive and PyTorch intersphinx URL
- make classification plotting compatible with current Matplotlib
- remove Masksembles docstring warnings

## Validation
- All checks passed!
- 