### PR TITLE
Fix wrong class probabilities in saved classification predictions

### DIFF
--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -302,7 +302,7 @@ def save_classification_predictions(outputs: dict[str, Tensor], path: str) -> No
     pred_class = torch.argmax(class_probs, dim=1).cpu().numpy()
 
     for i in range(class_probs.shape[1]):
-        outputs[f"class_prob_{i}"] = class_probs[:, 1]
+        outputs[f"class_prob_{i}"] = class_probs[:, i]
 
     cpu_outputs = {}
     for key, val in outputs.items():

--- a/tests/uq_methods/test_utils.py
+++ b/tests/uq_methods/test_utils.py
@@ -5,12 +5,16 @@
 
 from pathlib import Path
 
+import pandas as pd
 import pytest
 import torch
 from conftest import minimal_cli_overrides
 
 from lightning_uq_box.main import get_uq_box_cli
-from lightning_uq_box.uq_methods.utils import checkpoint_loader
+from lightning_uq_box.uq_methods.utils import (
+    checkpoint_loader,
+    save_classification_predictions,
+)
 
 
 class TestUQMethods:
@@ -69,3 +73,20 @@ class TestUQMethods:
                     "model." + param_tensor
                 ],
             )
+
+
+def test_save_classification_predictions(tmp_path: Path) -> None:
+    """Each class_prob_i column should hold the probability of class i."""
+    class_probs = torch.tensor([[0.1, 0.2, 0.7], [0.6, 0.3, 0.1]])
+    path = str(tmp_path / "preds.csv")
+
+    save_classification_predictions(
+        {"pred": class_probs.clone(), "target": torch.tensor([2, 0])}, path
+    )
+
+    df = pd.read_csv(path)
+    assert df["pred"].tolist() == [2, 0]
+    for i in range(class_probs.shape[1]):
+        assert df[f"class_prob_{i}"].tolist() == pytest.approx(
+            class_probs[:, i].tolist()
+        )


### PR DESCRIPTION
`save_classification_predictions` wrote class 1's probability into *every* `class_prob_i` column:

```python
for i in range(class_probs.shape[1]):
    outputs[f"class_prob_{i}"] = class_probs[:, 1]   # should be [:, i]
```

Every per-class probability column in every saved classification `preds.csv` was therefore wrong. The `pred` column (argmax) and all logged metrics are computed elsewhere and were unaffected — only the persisted artifact — which is why the end-to-end suite never caught it. No test exercised `save_classification_predictions` at all.

**This changes the content of saved classification CSVs.** There is no changelog file in the repo, so this note stands in for one.

Adds a unit test that calls the function directly with distinguishable columns, reads the CSV back, and asserts each `class_prob_i` matches column `i`. Verified red before the fix (all columns came back as class 1's values) and green after. Full suite: 405 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011B3mFW7Myfb8dRtgzFMdZB