### PR TITLE
Correct the on_test_batch_end signature on 36 UQ methods

### DIFF
--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -308,12 +308,17 @@ class DeterministicRegression(DeterministicModel):
         self.test_metrics = default_regression_metrics("test")
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -396,12 +401,17 @@ class DeterministicClassification(DeterministicModel):
         return process_classification_prediction(out, aggregate_fn=identity)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/bnn_lv_vi.py
+++ b/lightning_uq_box/uq_methods/bnn_lv_vi.py
@@ -497,12 +497,17 @@ class BNN_LV_VI_Regression(BNN_LV_VI_Base):
         self.test_metrics = default_regression_metrics("test")
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -828,12 +833,17 @@ class BNN_LV_VI_Batched_Regression(BNN_LV_VI_Batched_Base):
         self.test_metrics = default_regression_metrics("test")
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/bnn_vi.py
+++ b/lightning_uq_box/uq_methods/bnn_vi.py
@@ -402,12 +402,17 @@ class BNN_VI_Regression(BNN_VI_Base):
         return energy_loss, mean_out.detach()
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/bnn_vi_elbo.py
+++ b/lightning_uq_box/uq_methods/bnn_vi_elbo.py
@@ -415,12 +415,17 @@ class BNN_VI_ELBO_Regression(BNN_VI_ELBO_Base):
         return process_regression_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -561,12 +566,17 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
         return process_classification_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/cards.py
+++ b/lightning_uq_box/uq_methods/cards.py
@@ -732,12 +732,17 @@ class CARDClassification(CARDBase):
         return pred_dict
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/conformal_qr.py
+++ b/lightning_uq_box/uq_methods/conformal_qr.py
@@ -6,6 +6,7 @@
 import copy
 import math
 import os
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -221,12 +222,17 @@ class ConformalQR(PosthocBase):
         pass
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/deep_ensemble.py
+++ b/lightning_uq_box/uq_methods/deep_ensemble.py
@@ -147,12 +147,17 @@ class DeepEnsembleRegression(DeepEnsemble):
         return pred_dict
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -216,12 +221,17 @@ class DeepEnsembleClassification(DeepEnsemble):
         return process_classification_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/deep_evidential_regression.py
+++ b/lightning_uq_box/uq_methods/deep_evidential_regression.py
@@ -181,12 +181,17 @@ class DER(DeterministicModel):
         return torch.reciprocal(torch.sqrt(nu))
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/deep_kernel_learning.py
+++ b/lightning_uq_box/uq_methods/deep_kernel_learning.py
@@ -362,12 +362,17 @@ class DKLRegression(DKLBase):
             self.likelihood = self.likelihood.cuda()
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -603,12 +608,17 @@ class DKLClassification(DKLBase):
         return {"pred": mean, "pred_uct": entropy, "out": gp_dist, "logits": mean}
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/density_uncertainty.py
+++ b/lightning_uq_box/uq_methods/density_uncertainty.py
@@ -364,12 +364,17 @@ class DensityLayerModelRegression(DensityLayerModelBase):
         return process_regression_prediction(y_hat)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -482,12 +487,17 @@ class DensityLayerModelClassification(DensityLayerModelBase):
         return process_classification_prediction(y_hat)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/inference_time_augmentation.py
+++ b/lightning_uq_box/uq_methods/inference_time_augmentation.py
@@ -275,12 +275,17 @@ class TTARegression(TTABase):
         return pred_dict
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -372,12 +377,17 @@ class TTAClassification(TTABase):
         return pred_dict
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/laplace_model.py
+++ b/lightning_uq_box/uq_methods/laplace_model.py
@@ -370,12 +370,17 @@ class LaplaceRegression(LaplaceBase):
         return self.forward(input)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -490,12 +495,17 @@ class LaplaceClassification(LaplaceBase):
         return pred_dict
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/masked_ensemble.py
+++ b/lightning_uq_box/uq_methods/masked_ensemble.py
@@ -294,12 +294,17 @@ class MasksemblesRegression(MasksemblesBase):
         return process_regression_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -401,12 +406,17 @@ class MasksemblesClassification(MasksemblesBase):
         return process_classification_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -256,12 +256,17 @@ class MCDropoutRegression(MCDropoutBase):
         return process_regression_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -361,12 +366,17 @@ class MCDropoutClassification(MCDropoutBase):
         return process_classification_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/mean_variance_estimation.py
+++ b/lightning_uq_box/uq_methods/mean_variance_estimation.py
@@ -142,12 +142,17 @@ class MVERegression(MVEBase):
         return {"pred": mean, "pred_uct": std, "aleatoric_uct": std, "out": preds}
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/quantile_regression.py
+++ b/lightning_uq_box/uq_methods/quantile_regression.py
@@ -161,12 +161,17 @@ class QuantileRegression(QuantileRegressionBase):
         }
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/raps.py
+++ b/lightning_uq_box/uq_methods/raps.py
@@ -13,6 +13,7 @@ to be integrated with Lightning and port several functions to pytorch.
 
 import os
 from functools import partial
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -258,12 +259,17 @@ class RAPS(PosthocBase):
         self.post_hoc_fitted = True
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/sgld.py
+++ b/lightning_uq_box/uq_methods/sgld.py
@@ -278,12 +278,17 @@ class SGLDRegression(SGLDBase):
         return process_regression_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -409,12 +414,17 @@ class SGLDClassification(SGLDBase):
         return process_classification_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/sngp.py
+++ b/lightning_uq_box/uq_methods/sngp.py
@@ -7,6 +7,7 @@
 
 import math
 import os
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -328,12 +329,17 @@ class SNGPRegression(SNGPBase):
         self.test_metrics = default_regression_metrics("test")
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -444,12 +450,17 @@ class SNGPClassification(SNGPBase):
         return logits
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/swag.py
+++ b/lightning_uq_box/uq_methods/swag.py
@@ -383,12 +383,17 @@ class SWAGRegression(SWAGBase):
         self.test_metrics = default_regression_metrics("test")
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -509,12 +514,17 @@ class SWAGClassification(SWAGBase):
         return process_classification_prediction(preds)
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/temp_scaling.py
+++ b/lightning_uq_box/uq_methods/temp_scaling.py
@@ -5,6 +5,7 @@ Adapted from https://github.com/gpleiss/temperature_scaling/blob/master/temperat
 
 import os
 from functools import partial
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -135,12 +136,17 @@ class TempScaling(PosthocBase):
         return out_dict
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/lightning_uq_box/uq_methods/zigzag.py
+++ b/lightning_uq_box/uq_methods/zigzag.py
@@ -9,6 +9,7 @@
 """ZigZag Universal Sampling-free Uncertainty Estimation."""
 
 import os
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -268,12 +269,17 @@ class ZigZagRegression(ZigZagBase):
         return {"pred": Y_1, "pred_uct": torch.linalg.norm(Y_1 - Y_2, dim=1)}
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """
@@ -365,12 +371,17 @@ class ZigZagClassification(ZigZagBase):
         }
 
     def on_test_batch_end(
-        self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+        self,
+        outputs: dict[str, Tensor],
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
     ) -> None:
         """Test batch end save predictions.
 
         Args:
             outputs: dictionary of model outputs and aux variables
+            batch: batch from dataloader
             batch_idx: batch index
             dataloader_idx: dataloader index
         """

--- a/tests/uq_methods/test_hook_signatures.py
+++ b/tests/uq_methods/test_hook_signatures.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Test that Lightning hooks are declared with Lightning's own signature."""
+
+import inspect
+
+import pytest
+from lightning import LightningModule
+
+import lightning_uq_box.uq_methods as uq_methods
+
+HOOKS = ["on_test_batch_end"]
+
+
+def _classes_defining(hook: str) -> list[type]:
+    """Exported UQ methods that define their own version of ``hook``.
+
+    Args:
+        hook: name of the Lightning hook
+
+    Returns:
+        list of classes with ``hook`` in their own ``__dict__``
+    """
+    return [
+        obj
+        for name in uq_methods.__all__
+        if isinstance(obj := getattr(uq_methods, name), type)
+        and issubclass(obj, LightningModule)
+        and hook in obj.__dict__
+    ]
+
+
+@pytest.mark.parametrize("hook", HOOKS)
+def test_hook_is_defined_by_some_class(hook: str) -> None:
+    assert _classes_defining(hook), f"no exported class overrides {hook}"
+
+
+@pytest.mark.parametrize(
+    "hook,cls",
+    [(hook, cls) for hook in HOOKS for cls in _classes_defining(hook)],
+    ids=lambda p: p if isinstance(p, str) else p.__name__,
+)
+def test_hook_signature_matches_lightning(hook: str, cls: type) -> None:
+    expected = list(inspect.signature(getattr(LightningModule, hook)).parameters)
+    actual = list(inspect.signature(cls.__dict__[hook]).parameters)
+    assert actual == expected, (
+        f"{cls.__name__}.{hook} declares {actual}, but Lightning calls it "
+        f"positionally with {expected}"
+    )


### PR DESCRIPTION
Lightning's hook is `on_test_batch_end(self, outputs, batch, batch_idx, dataloader_idx=0)` and is called positionally. 36 classes across 22 files declared it as

```python
def on_test_batch_end(
    self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
) -> None:
```

so they received the batch itself in `batch_idx` and the batch index in `dataloader_idx`.

**Behaviour-neutral.** An AST scan confirms none of the 36 reference `batch_idx` in their bodies — they all hand `outputs` to `save_regression_predictions` / `save_classification_predictions`, which ignore the argument. The split is diagnostic of copy-paste: all 15 classes that were already correct are the image/dense-task ones, which pass `batch_idx` to `save_image_predictions` to build filenames and so were forced to get it right.

Adds `tests/uq_methods/test_hook_signatures.py`, which walks every exported class in `uq_methods.__all__` that overrides `on_test_batch_end` and compares its parameter names against `LightningModule`'s via `inspect.signature`. Run against `main` it reports exactly the 36 known offenders; after the fix all 51 pass. It's parametrized over a `HOOKS` list so other hooks can be added to the same guard.

Full suite: 456 passed. `ruff check`, `ruff format --check`, `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011B3mFW7Myfb8dRtgzFMdZB