### PR TITLE
Type check lightning_uq_box/models with ty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,11 @@ Configured in `pyproject.toml`; `ruff format` decides layout, so do not hand-for
 ### Type Hints (ty)
 
 - [ty](https://docs.astral.sh/ty/) replaces mypy. `[tool.ty.src]` checks `lightning_uq_box` and
-  `tests`; `lightning_uq_box/uq_methods` and `lightning_uq_box/models` are excluded until they are
-  annotated. New code elsewhere must be annotated and must pass `uv run ty check`.
+  `tests`; only `lightning_uq_box/uq_methods` is still excluded, until it is annotated. New code
+  elsewhere must be annotated and must pass `uv run ty check`.
+- Attributes registered in `__init__` via `register_buffer` / `register_parameter`, or assigned in
+  a subclass and read from a base class, need a class-level declaration (`mu_weight: Parameter`).
+  Without one, `nn.Module.__getattr__` types them as `Tensor | Module` and every use is an error.
 - Union: `X | Y`, not `Union[X, Y]`; prefer built-in `list`/`dict`/`tuple` over `typing.List` etc.
 - `# ty: ignore[<rule>]` only for external library issues, with a comment saying which one.
 

--- a/lightning_uq_box/models/bnn_layers/base_variational.py
+++ b/lightning_uq_box/models/bnn_layers/base_variational.py
@@ -39,6 +39,7 @@ adjusted to be trained with the Energy Loss and support batched inputs.
 """
 
 import math
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn
@@ -55,6 +56,22 @@ class BaseVariationalLayer_(nn.Module):
     """Base Variational Layer for BNN Layers."""
 
     valid_layer_types = ["reparameterization", "flipout"]
+
+    # Registered by define_bayesian_weight_params() in the subclasses. Declared here so
+    # they read as tensors rather than through nn.Module.__getattr__, which returns
+    # `Tensor | Module`. The bias variants are registered as None when bias=False.
+    mu_weight: Parameter
+    rho_weight: Parameter
+    eps_weight: Tensor
+    prior_weight_mu: Tensor
+    prior_weight_sigma: Tensor
+    mu_bias: Parameter | None
+    rho_bias: Parameter | None
+    eps_bias: Tensor | None
+    prior_bias_mu: Tensor | None
+    prior_bias_sigma: Tensor | None
+    # set by the ConvNd subclasses in conv_variational.py
+    conv_function: Callable[..., Tensor]
 
     def __init__(
         self,
@@ -106,11 +123,18 @@ class BaseVariationalLayer_(nn.Module):
 
         self.mu_weight.data.normal_(mean=self.posterior_mu_init, std=0.1)
         self.rho_weight.data.normal_(mean=self.posterior_rho_init, std=0.0)
-        if self.bias:
-            self.prior_bias_mu.data.fill_(self.prior_mu)
-            self.prior_bias_sigma.fill_(self.prior_sigma)
-            self.mu_bias.data.normal_(mean=self.posterior_mu_init, std=0.1)
-            self.rho_bias.data.normal_(mean=self.posterior_rho_init, std=0.0)
+        prior_bias_mu, prior_bias_sigma = self.prior_bias_mu, self.prior_bias_sigma
+        mu_bias, rho_bias = self.mu_bias, self.rho_bias
+        if (
+            prior_bias_mu is not None
+            and prior_bias_sigma is not None
+            and mu_bias is not None
+            and rho_bias is not None
+        ):
+            prior_bias_mu.data.fill_(self.prior_mu)
+            prior_bias_sigma.fill_(self.prior_sigma)
+            mu_bias.data.normal_(mean=self.posterior_mu_init, std=0.1)
+            rho_bias.data.normal_(mean=self.posterior_rho_init, std=0.0)
 
     def calc_log_Z_prior(self) -> Tensor:
         """Compute log Z prior.
@@ -119,7 +143,7 @@ class BaseVariationalLayer_(nn.Module):
             tensor of shape 0
         """
         n_params = self.mu_weight.numel()
-        if self.bias:
+        if self.mu_bias is not None:
             n_params += self.mu_bias.numel()
         return torch.tensor(
             0.5 * n_params * math.log(self.prior_sigma**2 * 2 * math.pi)
@@ -138,10 +162,11 @@ class BaseVariationalLayer_(nn.Module):
         log_normalizer = calc_log_normalizer(m_W=self.mu_weight, std_W=sigma_weight)
 
         # get log_normalizer for biases
-        if self.mu_bias is not None:
-            sigma_bias = torch.log1p(torch.exp(self.rho_bias))
+        mu_bias, rho_bias = self.mu_bias, self.rho_bias
+        if mu_bias is not None and rho_bias is not None:
+            sigma_bias = torch.log1p(torch.exp(rho_bias))
             log_normalizer = log_normalizer + calc_log_normalizer(
-                m_W=self.mu_bias, std_W=sigma_bias
+                m_W=mu_bias, std_W=sigma_bias
             )
 
         return log_normalizer
@@ -170,13 +195,14 @@ class BaseVariationalLayer_(nn.Module):
         bias = None
         # get log_f_hat for biases
         # first sample bias
-        if self.mu_bias is not None:
-            sigma_bias = torch.log1p(torch.exp(self.rho_bias))
-            delta_bias = sigma_bias * self.eps_bias
-            bias = self.mu_bias + delta_bias
+        mu_bias, rho_bias, eps_bias = self.mu_bias, self.rho_bias, self.eps_bias
+        if mu_bias is not None and rho_bias is not None and eps_bias is not None:
+            sigma_bias = torch.log1p(torch.exp(rho_bias))
+            delta_bias = sigma_bias * eps_bias
+            bias = mu_bias + delta_bias
             # compute log_f_hat for weights and biases
             log_f_hat = log_f_hat + calc_log_f_hat(
-                w=bias, m_W=self.mu_bias, std_W=sigma_bias, prior_sigma=self.prior_sigma
+                w=bias, m_W=mu_bias, std_W=sigma_bias, prior_sigma=self.prior_sigma
             )
 
         return log_f_hat
@@ -221,11 +247,16 @@ class BaseVariationalLayer_(nn.Module):
         kl = self.kl_div(
             self.mu_weight, sigma_weight, self.prior_weight_mu, self.prior_weight_sigma
         )
-        if self.bias:
-            sigma_bias = torch.log1p(torch.exp(self.rho_bias))
-            kl += self.kl_div(
-                self.mu_bias, sigma_bias, self.prior_bias_mu, self.prior_bias_sigma
-            )
+        mu_bias, rho_bias = self.mu_bias, self.rho_bias
+        prior_bias_mu, prior_bias_sigma = self.prior_bias_mu, self.prior_bias_sigma
+        if (
+            mu_bias is not None
+            and rho_bias is not None
+            and prior_bias_mu is not None
+            and prior_bias_sigma is not None
+        ):
+            sigma_bias = torch.log1p(torch.exp(rho_bias))
+            kl += self.kl_div(mu_bias, sigma_bias, prior_bias_mu, prior_bias_sigma)
         return kl
 
 
@@ -376,16 +407,17 @@ class BaseConvLayer_(BaseVariationalLayer_):
 
         bias = None
         delta_bias = None
-        if self.bias:
+        mu_bias, rho_bias = self.mu_bias, self.rho_bias
+        if mu_bias is not None and rho_bias is not None and self.eps_bias is not None:
             if self.is_frozen:
                 eps_bias = self.eps_bias
             else:
                 eps_bias = self.eps_bias.data.normal_()
             # compute variance of bias from unconstrained variable rho_bias
-            sigma_bias = torch.log1p(torch.exp(self.rho_bias))
+            sigma_bias = torch.log1p(torch.exp(rho_bias))
             # compute delta_bias
             delta_bias = sigma_bias * eps_bias
-            bias = self.mu_bias + delta_bias
+            bias = mu_bias + delta_bias
 
         if self.layer_type == "reparameterization":
             weight = self.mu_weight + delta_weight

--- a/lightning_uq_box/models/bnn_layers/bnn_utils.py
+++ b/lightning_uq_box/models/bnn_layers/bnn_utils.py
@@ -148,11 +148,13 @@ def get_kl_loss(model: nn.Module) -> Tensor:
     """
     kl_loss = None
     for layer in model.modules():
-        if hasattr(layer, "kl_loss"):
+        # importing BaseVariationalLayer_ here would be circular, so duck-type instead
+        layer_kl_loss = getattr(layer, "kl_loss", None)
+        if callable(layer_kl_loss):
             if kl_loss is None:
-                kl_loss = layer.kl_loss()
+                kl_loss = layer_kl_loss()
             else:
-                kl_loss += layer.kl_loss()
+                kl_loss += layer_kl_loss()
     assert kl_loss is not None
     return kl_loss
 

--- a/lightning_uq_box/models/bnn_layers/linear_variational.py
+++ b/lightning_uq_box/models/bnn_layers/linear_variational.py
@@ -187,7 +187,7 @@ class LinearVariational(BaseVariationalLayer_):
         if self.layer_type == "reparameterization":
             # sample weight via reparameterization trick
             output = x.matmul((self.mu_weight + delta_weight).transpose(-1, -2))
-            if self.bias:
+            if self.mu_bias is not None:
                 output = output + (self.mu_bias + delta_bias).unsqueeze(1)
         else:
             # linear outputs
@@ -221,14 +221,15 @@ class LinearVariational(BaseVariationalLayer_):
         # Get device from parameters (not buffers, as they might be on CPU)
         device = self.rho_weight.device
 
+        eps_bias = self.eps_bias
         if self.is_frozen:
             eps_weight = self.eps_weight.to(device)
-            if self.mu_bias is not None:
-                bias_eps = self.eps_bias.to(device)
+            if eps_bias is not None:
+                bias_eps = eps_bias.to(device)
         else:
             eps_weight = self.eps_weight.data.normal_().to(device)
-            if self.mu_bias is not None:
-                bias_eps = self.eps_bias.data.normal_().to(device)
+            if eps_bias is not None:
+                bias_eps = eps_bias.data.normal_().to(device)
 
         # select from max_samples
         eps_weight = eps_weight[:n_samples]
@@ -239,11 +240,12 @@ class LinearVariational(BaseVariationalLayer_):
 
         delta_bias = torch.zeros(1, device=device, dtype=self.rho_weight.dtype)
 
-        if self.mu_bias is not None:
+        rho_bias = self.rho_bias
+        if rho_bias is not None:
             bias_eps = bias_eps[:n_samples]
 
             # sample bias with reparameterization trick
-            sigma_bias = F.softplus(self.rho_bias)
+            sigma_bias = F.softplus(rho_bias)
             delta_bias = bias_eps * sigma_bias
         return delta_weight, delta_bias
 

--- a/lightning_uq_box/models/bnn_layers/rnn_layer.py
+++ b/lightning_uq_box/models/bnn_layers/rnn_layer.py
@@ -122,7 +122,7 @@ class LSTMVariational(BaseVariationalLayer_):
         Returns:
             tensor of shape 0
         """
-        if self.bias:
+        if self.hh.mu_bias is not None and self.ih.mu_bias is not None:
             n_params = (
                 self.hh.mu_weight.numel()
                 + self.hh.mu_bias.numel()

--- a/lightning_uq_box/models/bnnlv/utils.py
+++ b/lightning_uq_box/models/bnnlv/utils.py
@@ -25,11 +25,12 @@ def get_log_normalizer(models: list[nn.Module]):
     log_normalizer = None
     for m in models:
         for layer in m.modules():
-            if hasattr(layer, "log_normalizer"):
+            layer_log_normalizer = getattr(layer, "log_normalizer", None)
+            if callable(layer_log_normalizer):
                 if log_normalizer is None:
-                    log_normalizer = layer.log_normalizer()
+                    log_normalizer = layer_log_normalizer()
                 else:
-                    log_normalizer += layer.log_normalizer()
+                    log_normalizer += layer_log_normalizer()
     return log_normalizer
 
 
@@ -49,11 +50,12 @@ def get_log_f_hat(models: list[nn.Module]):
     log_f_hat = None
     for m in models:
         for layer in m.modules():
-            if hasattr(layer, "log_f_hat"):
+            layer_log_f_hat = getattr(layer, "log_f_hat", None)
+            if callable(layer_log_f_hat):
                 if log_f_hat is None:
-                    log_f_hat = layer.log_f_hat()
+                    log_f_hat = layer_log_f_hat()
                 else:
-                    log_f_hat += layer.log_f_hat()
+                    log_f_hat += layer_log_f_hat()
     return log_f_hat
 
 
@@ -70,11 +72,12 @@ def get_log_Z_prior(models: list[nn.Module]):
     log_Z_prior = None
     for m in models:
         for layer in m.modules():
-            if hasattr(layer, "calc_log_Z_prior"):
+            layer_log_Z_prior = getattr(layer, "calc_log_Z_prior", None)
+            if callable(layer_log_Z_prior):
                 if log_Z_prior is None:
-                    log_Z_prior = layer.calc_log_Z_prior()
+                    log_Z_prior = layer_log_Z_prior()
                 else:
-                    log_Z_prior += layer.calc_log_Z_prior()
+                    log_Z_prior += layer_log_Z_prior()
     return log_Z_prior
 
 

--- a/lightning_uq_box/models/cards.py
+++ b/lightning_uq_box/models/cards.py
@@ -47,7 +47,8 @@ class ConditionalLinear(nn.Module):
 class DiffusionSequential(nn.Sequential):
     """My Sequential to accept multiple inputs."""
 
-    def forward(self, input: Tensor, t: Tensor) -> Tensor:  # type: ignore[override]
+    # a Sequential that threads the diffusion time step through every block
+    def forward(self, input: Tensor, t: Tensor) -> Tensor:  # ty: ignore[invalid-method-override]
         """Forward pass.
 
         Args:
@@ -174,6 +175,7 @@ class ConditionalGuidedConvModel(nn.Module):
         self.n_steps = cond_guide_model.n_steps
 
         _, module = _get_output_layer_name_and_module(self.encoder)
+        assert isinstance(module, nn.Linear)
         encoder_out_features = module.out_features
 
         assert encoder_out_features == cond_guide_model.x_dim, (

--- a/lightning_uq_box/models/density_layers.py
+++ b/lightning_uq_box/models/density_layers.py
@@ -22,6 +22,18 @@ class DensityLayerBase_(nn.Module):
     implement specific density layers.
     """
 
+    # Registered in the subclasses' __init__. Declared here so they read as tensors
+    # rather than through nn.Module.__getattr__, which returns `Tensor | Module`.
+    s_prior_mu: Tensor
+    s_prior_logvar: Tensor
+    s_logvar: nn.Parameter
+    b_prior_mu: Tensor
+    b_prior_logvar: Tensor
+    b_logvar: nn.Parameter
+    logvar: nn.Parameter
+    L: nn.Parameter
+    I: Tensor  # noqa: E741 — buffer name, renaming would break checkpoints
+
     def kl_div(
         self, mu1: Tensor, logvar1: Tensor, mu2: Tensor, logvar2: Tensor
     ) -> Tensor:

--- a/lightning_uq_box/models/masked_conv.py
+++ b/lightning_uq_box/models/masked_conv.py
@@ -73,6 +73,9 @@ def weight_mask(in_channels: int, kernel_size: tuple[int, int]) -> torch.Tensor:
 class MaskedConv2d(nn.Module):
     """Masked 2D Convolutional Layer."""
 
+    # registered as a buffer in __init__
+    mask: Tensor
+
     def __init__(
         self,
         in_channels: int,

--- a/lightning_uq_box/models/masked_ensemble/utils.py
+++ b/lightning_uq_box/models/masked_ensemble/utils.py
@@ -38,10 +38,11 @@ def convert_deterministic_to_masked_ensemble(
                         scale=scale,
                         in_channels=value.in_channels,
                         out_channels=value.out_channels,
-                        kernel_size=value.kernel_size,  # type: ignore[arg-type]
-                        stride=value.stride,  # type: ignore[arg-type]
-                        padding=value.padding,  # type: ignore[arg-type]
-                        dilation=value.dilation,  # type: ignore[arg-type]
+                        # torch types these as tuple[int, ...], _size_2_t is tuple[int, int]
+                        kernel_size=value.kernel_size,  # ty: ignore[invalid-argument-type]
+                        stride=value.stride,  # ty: ignore[invalid-argument-type]
+                        padding=value.padding,  # ty: ignore[invalid-argument-type]
+                        dilation=value.dilation,  # ty: ignore[invalid-argument-type]
                         groups=value.groups,
                         bias=value.bias is not None,
                     ),

--- a/lightning_uq_box/models/vae.py
+++ b/lightning_uq_box/models/vae.py
@@ -80,7 +80,7 @@ class VAEDecoder(nn.Module):
         dec_out_channels = list(decoder_channels[1:])
 
         # combine decoder keyword arguments
-        blocks = [
+        blocks: list[nn.Module] = [
             DecoderBlock(in_ch, out_ch, use_batchnorm, attention_type)
             for in_ch, out_ch in zip(dec_in_channels, dec_out_channels)
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,9 +189,9 @@ USE_IOMP = "0"
 # https://docs.astral.sh/ty/reference/configuration/
 [tool.ty.src]
 include = ["lightning_uq_box", "tests"]
-# TODO: annotate these and drop the exclusions. uq_methods reports 619 diagnostics and
-# models 67, almost all from parameters assigned dynamically onto nn.Module.
-exclude = ["lightning_uq_box/uq_methods", "lightning_uq_box/models"]
+# TODO: annotate uq_methods and drop the exclusion. It reports 619 diagnostics, almost
+# all from parameters assigned dynamically onto nn.Module.
+exclude = ["lightning_uq_box/uq_methods"]
 
 [tool.ruff]
 extend-include = ["*.ipynb"]


### PR DESCRIPTION
Follow-up to #491, which gated everything except `models` and `uq_methods`. This clears **`models` (67 diagnostics)** and drops it from `[tool.ty.src] exclude`. `uq_methods` (619) stays excluded and is the subject of the next PRs.

### One cause, 48 of the 67

Attributes registered in `__init__` via `register_buffer` / `register_parameter`, or assigned in a subclass and read from a base class, have no class-level declaration — so `nn.Module.__getattr__` types them as `Tensor | Module` and every use is an error. The fix is to declare them on the class that reads them:

- `BaseVariationalLayer_` declares `mu_weight` / `rho_weight` / `eps_weight`, the prior buffers, and the bias variants. The bias ones are `| None`, matching how the subclasses register them (`register_parameter("mu_bias", None)` when `bias=False`) and matching how torch types `_ConvNd.bias`.
- `DensityLayerBase_` declares the buffers and parameters its `kl_div` reads.
- `MaskedConv2d` declares its `mask` buffer.

Because the bias attributes are now Optional, the guards that used them had to narrow. `if self.bias:` becomes a check on the attributes themselves — equivalent, since they are registered as `None` exactly when `bias=False`, and it ties the check to the thing being used. Where a block touches several of them they are bound to locals first so the narrowing carries.

### The rest

- `get_kl_loss` and the `bnnlv` getters looped with `hasattr(layer, "log_f_hat")` and then called `layer.log_f_hat()`, which ty cannot follow. Bind the attribute with `getattr` and test `callable()`. Importing the layer class to use `isinstance` would be circular.
- `cards.py` read `module.out_features` off an `nn.Module`. Assert it is an `nn.Linear` first, which is what the code already assumes.
- `vae.py` appended a `SegmentationHead` to a list inferred as `list[DecoderBlock]`. Annotate it `list[nn.Module]`.
- The four mypy-era `# type: ignore[arg-type]` in `masked_ensemble/utils.py` become `# ty: ignore[invalid-argument-type]` with a comment. torch types `Conv2d.kernel_size` as `tuple[int, ...]` while `_size_2_t` is `tuple[int, int]`, so these stay suppressed.
- `# type: ignore[override]` on `DiffusionSequential.forward` becomes `# ty: ignore[invalid-method-override]`. Threading the time step through a `Sequential` is deliberate.

The `I: Tensor` declaration needs a `noqa` for ruff's E741 — it is a buffer name, and renaming it would break existing checkpoints.

### Verification

`ruff check`/`format`, `ty check` (0 diagnostics), `pytest` (404 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdrE6md5VsMgFNR3MLiEjY
