### PR TITLE
Type check uq_methods, with the remaining rules muted per-directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,9 +73,13 @@ Configured in `pyproject.toml`; `ruff format` decides layout, so do not hand-for
 
 ### Type Hints (ty)
 
-- [ty](https://docs.astral.sh/ty/) replaces mypy. `[tool.ty.src]` checks `lightning_uq_box` and
-  `tests`; only `lightning_uq_box/uq_methods` is still excluded, until it is annotated. New code
-  elsewhere must be annotated and must pass `uv run ty check`.
+- [ty](https://docs.astral.sh/ty/) replaces mypy. `[tool.ty.src]` checks all of `lightning_uq_box`
+  and `tests`; nothing is excluded. New code must be annotated and must pass `uv run ty check`.
+- `lightning_uq_box/uq_methods` is checked with some rules muted in `[[tool.ty.overrides]]`, so
+  its remaining diagnostics can be fixed a family at a time. Do not add a rule to that block to
+  get a change to pass — fix the code, or suppress the one line with `# ty: ignore[<rule>]`.
+  `unresolved-attribute` is muted there permanently: Lightning types `hparams` as a
+  `MutableMapping`, so every `self.hparams.<name>` read is unresolved.
 - Attributes registered in `__init__` via `register_buffer` / `register_parameter`, or assigned in
   a subclass and read from a base class, need a class-level declaration (`mu_weight: Parameter`).
   Without one, `nn.Module.__getattr__` types them as `Tensor | Module` and every use is an error.

--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -336,7 +336,7 @@ class DeterministicClassification(DeterministicModel):
         task: str = "multiclass",
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Deterministic Classification Model.
 
@@ -423,7 +423,7 @@ class DeterministicSegmentation(DeterministicClassification):
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize a new Deterministic Segmentation Model.
@@ -522,7 +522,7 @@ class DeterministicPixelRegression(DeterministicRegression):
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize a new instance of Deterministic Pixel Regression.

--- a/lightning_uq_box/uq_methods/bnn_lv_vi.py
+++ b/lightning_uq_box/uq_methods/bnn_lv_vi.py
@@ -67,7 +67,7 @@ class BNN_LV_VI_Base(BNN_VI_Base):
         stochastic_module_names: list[str | int] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instace of BNN+LV.
 
@@ -544,7 +544,7 @@ class BNN_LV_VI_Batched_Base(BNN_LV_VI_Base):
         stochastic_module_names: list[str | int] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instace of BNN+LV Batched.
 

--- a/lightning_uq_box/uq_methods/bnn_vi.py
+++ b/lightning_uq_box/uq_methods/bnn_vi.py
@@ -4,6 +4,7 @@
 """Bayesian Neural Networks with Variational Inference and Latent Variables."""  # noqa: E501
 
 import os
+from collections.abc import Sequence
 from typing import Any
 
 import einops
@@ -55,7 +56,7 @@ class BNN_VI_Base(DeterministicModel):
         stochastic_module_names: list[str | int] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instace of BNN VI.
 
@@ -204,7 +205,10 @@ class BNN_VI_Base(DeterministicModel):
                 module.unfreeze_layer()
 
     def exclude_from_wt_decay(
-        self, named_params, weight_decay: float, skip_list: list[str] = ("mu", "rho")
+        self,
+        named_params,
+        weight_decay: float,
+        skip_list: Sequence[str] = ("mu", "rho"),
     ):
         """Exclude non VI parameters from weight_decay optimization.
 
@@ -298,7 +302,7 @@ class BNN_VI_Regression(BNN_VI_Base):
         stochastic_module_names: list[int] | list[str] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instace of BNN VI Regression.
 
@@ -475,7 +479,7 @@ class BNN_VI_BatchedRegression(BNN_VI_Regression):
         stochastic_module_names: list[str | int] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instace of BNN VI Batched.
 

--- a/lightning_uq_box/uq_methods/bnn_vi_elbo.py
+++ b/lightning_uq_box/uq_methods/bnn_vi_elbo.py
@@ -4,6 +4,7 @@
 """Bayesian Neural Networks with Variational Inference."""
 
 import os
+from collections.abc import Sequence
 from typing import Any
 
 import torch
@@ -57,7 +58,7 @@ class BNN_VI_ELBO_Base(DeterministicModel):
         stochastic_module_names: list[int | str] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Model instance.
 
@@ -240,7 +241,10 @@ class BNN_VI_ELBO_Base(DeterministicModel):
         raise NotImplementedError
 
     def exclude_from_wt_decay(
-        self, named_params, weight_decay: float, skip_list: list[str] = ("mu", "rho")
+        self,
+        named_params,
+        weight_decay: float,
+        skip_list: Sequence[str] = ("mu", "rho"),
     ):
         """Exclude non VI parameters from weight_decay optimization.
 
@@ -318,7 +322,7 @@ class BNN_VI_ELBO_Regression(BNN_VI_ELBO_Base):
         stochastic_module_names: list[int] | list[str] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Model instance.
 
@@ -457,7 +461,7 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
         stochastic_module_names: list[int] | list[str] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Model instance.
 
@@ -603,7 +607,7 @@ class BNN_VI_ELBO_Segmentation(BNN_VI_ELBO_Classification):
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize a new BNN VI ELBO Segmentation instance.

--- a/lightning_uq_box/uq_methods/cards.py
+++ b/lightning_uq_box/uq_methods/cards.py
@@ -53,7 +53,7 @@ class CARDBase(BaseModule):
         ema_update_every: float = 10,
         ema_update_after_step: int = 0,
         guidance_optim: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instance of the CARD Model.
 
@@ -644,7 +644,7 @@ class CARDClassification(CARDBase):
         ema_update_every: float = 10,
         ema_update_after_step: int = 0,
         guidance_optim: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instance of the CARD Classification.
 

--- a/lightning_uq_box/uq_methods/deep_evidential_regression.py
+++ b/lightning_uq_box/uq_methods/deep_evidential_regression.py
@@ -72,7 +72,7 @@ class DER(DeterministicModel):
         coeff: float = 0.01,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Base Model.
 
@@ -210,7 +210,7 @@ class DERPxRegression(DER):
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize a new instance of the DER for Pixelwise Regression.

--- a/lightning_uq_box/uq_methods/deep_kernel_learning.py
+++ b/lightning_uq_box/uq_methods/deep_kernel_learning.py
@@ -57,7 +57,7 @@ class DKLBase(gpytorch.Module, BaseModule):
         n_inducing_points: int,
         gp_kernel: str = "RBF",
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Deep Kernel Learning Model.
 
@@ -299,7 +299,7 @@ class DKLRegression(DKLBase):
         gp_kernel: str = "RBF",
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Deep Kernel Learning Model for Regression.
 
@@ -434,7 +434,7 @@ class DKLClassification(DKLBase):
         gp_kernel: str = "RBF",
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Deep Kernel Learning Model for Classification.
 

--- a/lightning_uq_box/uq_methods/density_uncertainty.py
+++ b/lightning_uq_box/uq_methods/density_uncertainty.py
@@ -115,7 +115,7 @@ class DensityLayerModelBase(DeterministicModel):
         stochastic_module_names: list[int | str] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a Density Layer Model.
 
@@ -290,7 +290,7 @@ class DensityLayerModelRegression(DensityLayerModelBase):
         stochastic_module_names: list[int | str] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a Density Layer Model for Regression Tasks.
 
@@ -397,7 +397,7 @@ class DensityLayerModelClassification(DensityLayerModelBase):
         stochastic_module_names: list[int | str] | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a Density Layer Model for Classification Tasks.
 

--- a/lightning_uq_box/uq_methods/deterministic_uncertainty_estimation.py
+++ b/lightning_uq_box/uq_methods/deterministic_uncertainty_estimation.py
@@ -33,7 +33,7 @@ class DUERegression(DKLRegression):
         n_power_iterations: int = 1,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Deterministic Uncertainty Estimation Model.
 
@@ -92,7 +92,7 @@ class DUEClassification(DKLClassification):
         n_power_iterations: int = 1,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new Deterministic Uncertainty Estimation Model.
 

--- a/lightning_uq_box/uq_methods/inference_time_augmentation.py
+++ b/lightning_uq_box/uq_methods/inference_time_augmentation.py
@@ -121,7 +121,7 @@ class TTABase(PosthocBase):
     def predict_step(
         self,
         X: Tensor,
-        aug: list[Callable] = None,
+        aug: list[Callable] | None = None,
         batch_idx: int = 0,
         dataloader_idx: int = 0,
     ) -> dict[str, Tensor]:
@@ -149,7 +149,9 @@ class TTABase(PosthocBase):
 
         aug_predictions: list[Tensor] | list[dict[str, Tensor]] = []
         if aug is None:
-            aug = self.tt_augmentation
+            # the concrete subclasses fill tt_augmentation in setup_task(); the base
+            # class with none configured just makes the un-augmented prediction
+            aug = self.tt_augmentation or []
         # first prediction with no augmentation
         aug_predictions.append(yield_prediction(X))
 

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -62,7 +62,7 @@ class MCDropoutBase(DeterministicModel):
         dropout_layer_names: list[str] = [],
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instance of MCDropoutModel.
 
@@ -157,7 +157,7 @@ class MCDropoutRegression(MCDropoutBase):
         dropout_layer_names: list[str] = [],
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instance of MC-Dropout Model for Regression.
 
@@ -290,7 +290,7 @@ class MCDropoutClassification(MCDropoutBase):
         dropout_layer_names: list[str] = [],
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instance of MC-Dropout Model for Classification.
 
@@ -390,7 +390,7 @@ class MCDropoutSegmentation(MCDropoutClassification):
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize a new instance of MC-Dropout Model for Segmentation.
@@ -508,7 +508,7 @@ class MCDropoutPxRegression(MCDropoutRegression):
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize a new instance of MC-Dropout Model for Pixel-wise Regression.

--- a/lightning_uq_box/uq_methods/mean_variance_estimation.py
+++ b/lightning_uq_box/uq_methods/mean_variance_estimation.py
@@ -35,7 +35,7 @@ class MVEBase(DeterministicModel):
         burnin_epochs: int,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instace of Deterministic Gaussian Model.
 
@@ -100,7 +100,7 @@ class MVERegression(MVEBase):
         burnin_epochs: int,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instance of Mean Variance Estimation Model for Regression.
 
@@ -170,7 +170,7 @@ class MVEPxRegression(DeterministicPixelRegression):
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize a new instance of MVE for Pixelwise Regression.

--- a/lightning_uq_box/uq_methods/quantile_regression.py
+++ b/lightning_uq_box/uq_methods/quantile_regression.py
@@ -39,7 +39,7 @@ class QuantileRegressionBase(DeterministicModel):
         quantiles: list[float] = [0.1, 0.5, 0.9],
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instance of Quantile Regression Model.
 
@@ -86,7 +86,7 @@ class QuantileRegression(QuantileRegressionBase):
         quantiles: list[float] = [0.1, 0.5, 0.9],
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new instance of Quantile Regression Model.
 
@@ -191,7 +191,7 @@ class QuantilePxRegression(QuantileRegressionBase):
         freeze_backbone: bool = False,
         freeze_decoder: bool = False,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize a new instance of Quantile Regression Model.

--- a/lightning_uq_box/uq_methods/sngp.py
+++ b/lightning_uq_box/uq_methods/sngp.py
@@ -59,7 +59,7 @@ class SNGPBase(BaseModule):
         input_size: int | None = None,
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new SNGP model.
 
@@ -369,7 +369,7 @@ class SNGPClassification(SNGPBase):
         task: str = "multiclass",
         freeze_backbone: bool = False,
         optimizer: OptimizerCallable = Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
     ) -> None:
         """Initialize a new SNGP model for classification.
 

--- a/lightning_uq_box/uq_methods/spectral_normalized_layers.py
+++ b/lightning_uq_box/uq_methods/spectral_normalized_layers.py
@@ -592,7 +592,7 @@ def spectral_norm_fc(
     n_power_iterations: int = 1,
     name: str = "weight",
     eps: float = 1e-12,
-    dim: int = None,
+    dim: int | None = None,
 ):
     """Apply spectral normalization.
 

--- a/lightning_uq_box/uq_methods/temp_scaling.py
+++ b/lightning_uq_box/uq_methods/temp_scaling.py
@@ -4,6 +4,7 @@ Adapted from https://github.com/gpleiss/temperature_scaling/blob/master/temperat
 """
 
 import os
+from collections.abc import Callable
 from functools import partial
 
 import torch
@@ -167,7 +168,9 @@ def run_temperature_optimization(
     labels: torch.Tensor,
     criterion: nn.Module,
     temperature: nn.Parameter,
-    optimizer: type[torch.optim.Optimizer] = partial(LBFGS, lr=0.01, max_iter=50),
+    optimizer: Callable[..., torch.optim.Optimizer] = partial(
+        LBFGS, lr=0.01, max_iter=50
+    ),
     max_iter: int | None = 50,
 ) -> Tensor:
     """Run temperature optimization.
@@ -183,26 +186,26 @@ def run_temperature_optimization(
     Returns:
         optimized temperature parameter
     """
-    optimizer = optimizer([temperature])
+    opt = optimizer([temperature])
 
     with torch.inference_mode(False):
         logits = logits.clone().requires_grad_(True)
-        if isinstance(optimizer, torch.optim.LBFGS):
+        if isinstance(opt, torch.optim.LBFGS):
 
             def closure():
-                optimizer.zero_grad()
+                opt.zero_grad()
                 loss = criterion(temp_scale_logits(logits, temperature), labels)
                 loss.backward()
                 return loss
 
-            optimizer.step(closure)
+            opt.step(closure)
         else:
             for _ in range(
                 max_iter
             ):  # You might need to adjust the number of iterations
-                optimizer.zero_grad()
+                opt.zero_grad()
                 loss = criterion(temp_scale_logits(logits, temperature), labels)
                 loss.backward()
-                optimizer.step()
+                opt.step()
 
     return temperature

--- a/lightning_uq_box/uq_methods/vae.py
+++ b/lightning_uq_box/uq_methods/vae.py
@@ -45,7 +45,7 @@ class VAE(DeterministicPixelRegression):
         freeze_decoder: bool = False,
         log_samples_every_n_steps: int = 500,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize the VAE.
@@ -367,7 +367,7 @@ class ConditionalVAE(VAE):
         freeze_decoder: bool = False,
         log_samples_every_n_steps: int = 500,
         optimizer: OptimizerCallable = torch.optim.Adam,
-        lr_scheduler: LRSchedulerCallable = None,
+        lr_scheduler: LRSchedulerCallable | None = None,
         save_preds: bool = False,
     ) -> None:
         """Initialize the Conditional VAE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,9 +189,32 @@ USE_IOMP = "0"
 # https://docs.astral.sh/ty/reference/configuration/
 [tool.ty.src]
 include = ["lightning_uq_box", "tests"]
-# TODO: annotate uq_methods and drop the exclusion. It reports 619 diagnostics, almost
-# all from parameters assigned dynamically onto nn.Module.
-exclude = ["lightning_uq_box/uq_methods"]
+
+# uq_methods is checked, but the rules it currently trips are muted so they can be fixed
+# a family at a time. Every other rule is enforced there from now on, so new code cannot
+# introduce a fresh class of problem. Each follow-up deletes one line from this block.
+[[tool.ty.overrides]]
+include = ["lightning_uq_box/uq_methods"]
+
+[tool.ty.overrides.rules]
+# Permanent. Lightning types LightningModule.hparams as a MutableMapping, so every
+# `self.hparams.<name>` read is unresolved. torchgeo mutes this rule globally.
+unresolved-attribute = "ignore"
+# TODO: fix and delete, one family per PR.
+call-non-callable = "ignore"
+empty-body = "ignore"
+index-out-of-bounds = "ignore"
+invalid-argument-type = "ignore"
+invalid-assignment = "ignore"
+invalid-method-override = "ignore"
+invalid-return-type = "ignore"
+invalid-type-arguments = "ignore"
+invalid-type-form = "ignore"
+missing-argument = "ignore"
+no-matching-overload = "ignore"
+not-subscriptable = "ignore"
+unknown-argument = "ignore"
+unsupported-operator = "ignore"
 
 [tool.ruff]
 extend-include = ["*.ipynb"]


### PR DESCRIPTION
Follow-up to #494. `lightning_uq_box/uq_methods` was excluded outright, so nothing in it was checked and nothing stopped it getting worse. It now comes out of `[tool.ty.src] exclude` and into a `[[tool.ty.overrides]]` block that mutes exactly the rules it currently trips.

**The directory is checked from here on.** Every rule not on that list is enforced, so new code cannot introduce a fresh class of problem, and each follow-up PR deletes one line from the block. Nothing is excluded from ty any more.

### `unresolved-attribute` is muted permanently

Lightning types `LightningModule.hparams` as a `MutableMapping`, so every `self.hparams.<name>` read is unresolved — 83 of the diagnostics. torchgeo mutes the same rule globally.

Worth stating the cost, since it is more than the hparams cases: it also covers the ~41 `Attribute X is not defined on Tensor in union Tensor | Module` hits, which the `nn.Module` declaration PR will fix as a side effect rather than under CI enforcement, and it means a typo'd hyperparameter name will not be caught.

### `invalid-parameter-default` is not on the list — all 44 are fixed here

- **39** are `lr_scheduler: LRSchedulerCallable = None` across 14 files. Add `| None`, which is what `base.py:115` already had — so this is a consistency fix as much as a typing one.
- `skip_list: list[str] = ("mu", "rho")` in `bnn_vi` and `bnn_vi_elbo` defaults to a tuple. The body only iterates it, so annotate `Sequence[str]`.
- `aug: list[Callable] = None` and `dim: int = None` get `| None`.
- `run_temperature_optimization` annotated `optimizer` as `type[torch.optim.Optimizer]` while defaulting it to a `partial`. It is only ever called to build an optimizer, so `Callable[..., Optimizer]` is correct. The instance it builds now gets its own name instead of rebinding the parameter.

### The ratchet caught something on its first day

Adding `| None` to `aug` surfaced that `TTABase.predict_step` iterates it without a guard. The concrete subclasses fill `tt_augmentation` in `setup_task()`, so this is unreachable in practice, but the base class with none configured would have raised. It now falls back to an empty list and makes the un-augmented prediction only.

That diagnostic came from `not-iterable` — a rule that is **not** in the mute list, which is exactly the behaviour the override block is meant to provide.

### What is left

| rule | count |
| --- | --- |
| `invalid-argument-type` | 110 |
| `invalid-method-override` | 87 |
| `call-non-callable` | 83 |
| `invalid-return-type` | 38 |
| `invalid-assignment` | 19 |
| `unsupported-operator` | 13 |
| the tail (8 rules) | 31 |

Next up is the `nn.Module` attribute declarations, which should take `call-non-callable` and a large share of `invalid-argument-type` together — the same fix that cleared `models` in #494.

### Verification

`ruff check`/`format`, `ty check` (0 diagnostics), `pytest` (405 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdrE6md5VsMgFNR3MLiEjY
