### PR TITLE
Make the multilabel classification task functional

### DIFF
--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -327,7 +327,7 @@ class DeterministicClassification(DeterministicModel):
 
     pred_file_name = "preds.csv"
 
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
 
     def __init__(
         self,
@@ -393,7 +393,9 @@ class DeterministicClassification(DeterministicModel):
         def identity(x, dim=None):
             return x
 
-        return process_classification_prediction(out, aggregate_fn=identity)
+        return process_classification_prediction(
+            out, aggregate_fn=identity, task=self.task
+        )
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -406,7 +408,9 @@ class DeterministicClassification(DeterministicModel):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 
@@ -483,7 +487,9 @@ class DeterministicSegmentation(DeterministicClassification):
         def identity(x, dim=None):
             return x
 
-        return process_segmentation_prediction(out, aggregate_fn=identity)
+        return process_segmentation_prediction(
+            out, aggregate_fn=identity, task=self.task
+        )
 
     def on_test_start(self) -> None:
         """Create logging directory and initialize metrics."""

--- a/lightning_uq_box/uq_methods/bnn_vi_elbo.py
+++ b/lightning_uq_box/uq_methods/bnn_vi_elbo.py
@@ -438,7 +438,7 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
     """
 
     pred_file_name = "preds.csv"
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
 
     def __init__(
         self,
@@ -558,7 +558,7 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
                 [self.model(X) for _ in range(self.hparams.num_mc_samples_test)], dim=-1
             )  # shape [batch_size, num_classes, num_samples]
 
-        return process_classification_prediction(preds)
+        return process_classification_prediction(preds, task=self.task)
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -571,7 +571,9 @@ class BNN_VI_ELBO_Classification(BNN_VI_ELBO_Base):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 
@@ -692,7 +694,7 @@ class BNN_VI_ELBO_Segmentation(BNN_VI_ELBO_Classification):
                 [self.model(X) for _ in range(self.hparams.num_mc_samples_test)], dim=-1
             )  # shape [batch_size, num_classes, height, width, num_samples]
 
-        return process_segmentation_prediction(preds)
+        return process_segmentation_prediction(preds, task=self.task)
 
     def on_test_start(self) -> None:
         """Create logging directory and initialize metrics."""

--- a/lightning_uq_box/uq_methods/cards.py
+++ b/lightning_uq_box/uq_methods/cards.py
@@ -726,7 +726,7 @@ class CARDClassification(CARDBase):
         final_recoverd = final_recoverd.permute(1, 2, 0).cpu()
 
         # momenet matching
-        pred_dict = process_classification_prediction(final_recoverd)
+        pred_dict = process_classification_prediction(final_recoverd, task=self.task)
         pred_dict["samples"] = y_tile_seq
 
         return pred_dict
@@ -743,7 +743,9 @@ class CARDClassification(CARDBase):
         """
         del outputs["samples"]
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 

--- a/lightning_uq_box/uq_methods/deep_ensemble.py
+++ b/lightning_uq_box/uq_methods/deep_ensemble.py
@@ -213,7 +213,7 @@ class DeepEnsembleClassification(DeepEnsemble):
         with torch.no_grad():
             preds = self.generate_ensemble_predictions(X)
 
-        return process_classification_prediction(preds)
+        return process_classification_prediction(preds, task=self.task)
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -226,7 +226,9 @@ class DeepEnsembleClassification(DeepEnsemble):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 
@@ -281,7 +283,7 @@ class DeepEnsembleSegmentation(DeepEnsembleClassification):
         with torch.no_grad():
             preds = self.generate_ensemble_predictions(X)
 
-        return process_segmentation_prediction(preds)
+        return process_segmentation_prediction(preds, task=self.task)
 
     def on_test_start(self) -> None:
         """Create logging directory and initialize metrics."""

--- a/lightning_uq_box/uq_methods/deep_kernel_learning.py
+++ b/lightning_uq_box/uq_methods/deep_kernel_learning.py
@@ -418,7 +418,7 @@ class DKLClassification(DKLBase):
     * https://arxiv.org/abs/2102.11409
     """
 
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
 
     # TODO
     # gp_layer: Callable[[only. the two args that are needed from computation],
@@ -613,7 +613,9 @@ class DKLClassification(DKLBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 

--- a/lightning_uq_box/uq_methods/density_uncertainty.py
+++ b/lightning_uq_box/uq_methods/density_uncertainty.py
@@ -381,7 +381,7 @@ class DensityLayerModelRegression(DensityLayerModelBase):
 class DensityLayerModelClassification(DensityLayerModelBase):
     """Density Layer Model for Classification Tasks."""
 
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
 
     def __init__(
         self,
@@ -479,7 +479,7 @@ class DensityLayerModelClassification(DensityLayerModelBase):
             y_hat = torch.stack(
                 [self.model(X) for _ in range(self.num_samples_test)], dim=-1
             )
-        return process_classification_prediction(y_hat)
+        return process_classification_prediction(y_hat, task=self.task)
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -492,5 +492,7 @@ class DensityLayerModelClassification(DensityLayerModelBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )

--- a/lightning_uq_box/uq_methods/inference_time_augmentation.py
+++ b/lightning_uq_box/uq_methods/inference_time_augmentation.py
@@ -294,14 +294,14 @@ class TTAClassification(TTABase):
 
     pred_file_name = "preds.csv"
 
-    valid_tasks: list[str] = ["binary", "multiclass", "multilable"]
+    valid_tasks: list[str] = ["binary", "multiclass", "multilabel"]
 
     def __init__(
         self,
         model: LightningModule | nn.Module,
         tt_augmentation: list[Callable[..., Any]] | None = None,
         merge_strategy: Literal["mean", "median", "sum", "max", "min"] = "mean",
-        task: Literal["binary", "multiclass", "multilable"] = "multiclass",
+        task: Literal["binary", "multiclass", "multilabel"] = "multiclass",
     ) -> None:
         """Initialize a new instance of TTA Classification module.
 
@@ -350,23 +350,23 @@ class TTAClassification(TTABase):
         """
         if self.merge_strategy == "mean":
             pred_dict = process_classification_prediction(
-                aug_tensor, aggregate_fn=torch.mean
+                aug_tensor, aggregate_fn=torch.mean, task=self.task
             )
         elif self.merge_strategy == "median":
             pred_dict = process_classification_prediction(
-                aug_tensor, aggregate_fn=torch_median_val_only
+                aug_tensor, aggregate_fn=torch_median_val_only, task=self.task
             )
         elif self.merge_strategy == "sum":
             pred_dict = process_classification_prediction(
-                aug_tensor, aggregate_fn=torch.sum
+                aug_tensor, aggregate_fn=torch.sum, task=self.task
             )
         elif self.merge_strategy == "max":
             pred_dict = process_classification_prediction(
-                aug_tensor, aggregate_fn=torch_max_val_only
+                aug_tensor, aggregate_fn=torch_max_val_only, task=self.task
             )
         elif self.merge_strategy == "min":
             pred_dict = process_classification_prediction(
-                aug_tensor, aggregate_fn=torch_min_val_only
+                aug_tensor, aggregate_fn=torch_min_val_only, task=self.task
             )
 
         return pred_dict
@@ -382,5 +382,7 @@ class TTAClassification(TTABase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )

--- a/lightning_uq_box/uq_methods/laplace_model.py
+++ b/lightning_uq_box/uq_methods/laplace_model.py
@@ -500,5 +500,7 @@ class LaplaceClassification(LaplaceBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )

--- a/lightning_uq_box/uq_methods/masked_ensemble.py
+++ b/lightning_uq_box/uq_methods/masked_ensemble.py
@@ -323,7 +323,7 @@ class MasksemblesClassification(MasksemblesBase):
 
     pred_file_name = "preds.csv"
 
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
 
     def __init__(
         self,
@@ -398,7 +398,7 @@ class MasksemblesClassification(MasksemblesBase):
         # rearange to put the estimators (samples) in the last dimension
         preds = rearrange(ensemble_pred, "(n b) ... -> b ... n", n=self.num_estimators)
 
-        return process_classification_prediction(preds)
+        return process_classification_prediction(preds, task=self.task)
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -411,5 +411,7 @@ class MasksemblesClassification(MasksemblesBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -279,7 +279,7 @@ class MCDropoutClassification(MCDropoutBase):
     """
 
     pred_file_name = "preds.csv"
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
 
     def __init__(
         self,
@@ -358,7 +358,7 @@ class MCDropoutClassification(MCDropoutBase):
                 [self.model(X) for _ in range(self.num_mc_samples)], dim=-1
             )  # shape [batch_size, num_outputs, num_samples]
 
-        return process_classification_prediction(preds)
+        return process_classification_prediction(preds, task=self.task)
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -371,7 +371,9 @@ class MCDropoutClassification(MCDropoutBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 
@@ -463,7 +465,7 @@ class MCDropoutSegmentation(MCDropoutClassification):
                 [self.model(X) for _ in range(self.hparams.num_mc_samples)], dim=-1
             )  # shape [batch_size, num_outputs, num_samples]
 
-        return process_segmentation_prediction(preds)
+        return process_segmentation_prediction(preds, task=self.task)
 
     def on_test_start(self) -> None:
         """Create logging directory and initialize metrics."""

--- a/lightning_uq_box/uq_methods/prob_unet.py
+++ b/lightning_uq_box/uq_methods/prob_unet.py
@@ -410,7 +410,7 @@ class ProbUNet(BaseModule):
             [self.sample(testing=True) for _ in range(self.num_samples)], dim=-1
         )  # shape: (batch_size, num_classes, height, width, num_samples)
 
-        return process_segmentation_prediction(samples)
+        return process_segmentation_prediction(samples, task=self.task)
 
     def configure_optimizers(self) -> dict[str, Any]:
         """Initialize the optimizer and learning rate scheduler.

--- a/lightning_uq_box/uq_methods/raps.py
+++ b/lightning_uq_box/uq_methods/raps.py
@@ -41,7 +41,7 @@ class RAPS(PosthocBase):
     * https://arxiv.org/abs/2009.14193
     """
 
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
     valid_lambda_criterion = ["size", "adaptiveness"]
     pred_file_name = "preds.csv"
 
@@ -170,7 +170,9 @@ class RAPS(PosthocBase):
 
             agg_func = identity
 
-        pred_dict = process_classification_prediction(scores, aggregate_fn=agg_func)
+        pred_dict = process_classification_prediction(
+            scores, aggregate_fn=agg_func, task=self.task
+        )
         pred_dict["pred_set"] = S
         pred_dict["size"] = torch.tensor([len(x) for x in S])
 
@@ -268,7 +270,9 @@ class RAPS(PosthocBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 

--- a/lightning_uq_box/uq_methods/sgld.py
+++ b/lightning_uq_box/uq_methods/sgld.py
@@ -406,7 +406,7 @@ class SGLDClassification(SGLDBase):
         preds = torch.stack(preds, dim=-1).detach()
         # shape [batch_size, num_outputs, n_sgld_samples]
 
-        return process_classification_prediction(preds)
+        return process_classification_prediction(preds, task=self.task)
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -419,5 +419,7 @@ class SGLDClassification(SGLDBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )

--- a/lightning_uq_box/uq_methods/sngp.py
+++ b/lightning_uq_box/uq_methods/sngp.py
@@ -454,7 +454,9 @@ class SNGPClassification(SNGPBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
     def predict_step(self, X: Tensor) -> dict[str, Tensor]:

--- a/lightning_uq_box/uq_methods/swag.py
+++ b/lightning_uq_box/uq_methods/swag.py
@@ -428,7 +428,7 @@ class SWAGClassification(SWAGBase):
     """  # noqa: E501
 
     pred_file_name = "preds.csv"
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
 
     def __init__(
         self,
@@ -506,7 +506,7 @@ class SWAGClassification(SWAGBase):
 
         preds = self.sample_predictions(X)
 
-        return process_classification_prediction(preds)
+        return process_classification_prediction(preds, task=self.task)
 
     def on_test_batch_end(
         self, outputs: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
@@ -519,7 +519,9 @@ class SWAGClassification(SWAGBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 
@@ -590,7 +592,7 @@ class SWAGSegmentation(SWAGClassification):
                 "SWAG is not fitted yet, please call trainer.fit() first."
             )
         preds = self.sample_predictions(X)
-        return process_segmentation_prediction(preds)
+        return process_segmentation_prediction(preds, task=self.task)
 
     def on_test_start(self) -> None:
         """Create logging directory and initialize metrics."""

--- a/lightning_uq_box/uq_methods/temp_scaling.py
+++ b/lightning_uq_box/uq_methods/temp_scaling.py
@@ -145,7 +145,9 @@ class TempScaling(PosthocBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )
 
 

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -80,7 +80,28 @@ def default_px_regression_metrics(prefix: str):
 
 
 def default_classification_metrics(prefix: str, task: str, num_classes: int):
-    """Return a set of default classification metrics."""
+    """Return a set of default classification metrics.
+
+    Args:
+        prefix: prefix for the metric names
+        task: one of "binary", "multiclass" or "multilabel"
+        num_classes: number of classes, or number of labels for the
+            "multilabel" task
+
+    Returns:
+        metric collection for the task
+    """
+    if task == "multilabel":
+        # CalibrationError has no multilabel variant, and EmpiricalCoverage is
+        # defined in terms of a single true label per sample, so neither is
+        # part of the multilabel metric set.
+        return MetricCollection(
+            {
+                "Acc": Accuracy(task=task, num_labels=num_classes),
+                "F1Score": F1Score(task=task, num_labels=num_classes),
+            },
+            prefix=prefix,
+        )
     return MetricCollection(
         {
             "Acc": Accuracy(task=task, num_classes=num_classes),
@@ -92,7 +113,25 @@ def default_classification_metrics(prefix: str, task: str, num_classes: int):
 
 
 def default_segmentation_metrics(prefix: str, task: str, num_classes: int):
-    """Return a set of default segmentation metrics."""
+    """Return a set of default segmentation metrics.
+
+    Args:
+        prefix: prefix for the metric names
+        task: one of "binary", "multiclass" or "multilabel"
+        num_classes: number of classes, or number of labels for the
+            "multilabel" task
+
+    Returns:
+        metric collection for the task
+    """
+    if task == "multilabel":
+        return MetricCollection(
+            {
+                "Jaccard": JaccardIndex(task=task, num_labels=num_classes),
+                "F1Score": F1Score(task=task, num_labels=num_classes),
+            },
+            prefix=prefix,
+        )
     return MetricCollection(
         {
             "Jaccard": JaccardIndex(task=task, num_classes=num_classes),
@@ -151,23 +190,35 @@ def process_regression_prediction(
 
 
 def process_classification_prediction(
-    logits: Tensor, aggregate_fn: Callable = torch.mean, eps: float = 1e-7
+    logits: Tensor,
+    aggregate_fn: Callable = torch.mean,
+    eps: float = 1e-7,
+    task: str = "multiclass",
 ) -> dict[str, Tensor]:
     """Process classification predictions.
 
     Applies softmax to logit and computes mean over the samples and entropy.
 
+    For the "multilabel" task the labels are not mutually exclusive, so a
+    sigmoid is applied per label and the uncertainty is the sum of the
+    per-label binary entropies.
+
     Args:
         logits: prediction logits tensor of shape [batch_size, num_classes, num_samples]
         aggregate_fn: function to aggregate over the samples
         eps: small value to prevent log of 0
-        agg_logits_first: whether to aggregate the logits first or take the softmax
-            first and then aggregate
+        task: one of "binary", "multiclass" or "multilabel"
 
     Returns:
         dictionary with aggregated class probabilities [batch_size, num_classes]
             and predictive uncertainty [batch_size]
     """
+    if task == "multilabel":
+        mean = aggregate_fn(torch.sigmoid(logits), dim=-1)
+        mean = mean.clamp(eps, 1 - eps)
+        entropy = -(mean * mean.log() + (1 - mean) * (1 - mean).log()).sum(dim=-1)
+        return {"pred": mean, "pred_uct": entropy, "logits": logits}
+
     mean = aggregate_fn(nn.functional.softmax(logits, dim=1), dim=-1)
     # prevent log of 0 -> nan
     mean.clamp_min_(eps)
@@ -176,23 +227,37 @@ def process_classification_prediction(
 
 
 def process_segmentation_prediction(
-    logits: Tensor, aggregate_fn: Callable = torch.mean, eps: float = 1e-7
+    logits: Tensor,
+    aggregate_fn: Callable = torch.mean,
+    eps: float = 1e-7,
+    task: str = "multiclass",
 ) -> dict[str, Tensor]:
     """Process segmentation predictions.
 
     Applies softmax to logit and computes mean over the samples and entropy.
+
+    For the "multilabel" task the labels are not mutually exclusive, so a
+    sigmoid is applied per label and the uncertainty is the sum of the
+    per-label binary entropies.
 
     Args:
         logits: prediction logits tensor of shape
             [batch_size, num_classes, height, width, num_samples]
         aggregate_fn: function to aggregate over the samples
         eps: small value to prevent log of 0
+        task: one of "binary", "multiclass" or "multilabel"
 
     Returns:
         dictionary with pixel class probabilities
             [batch_size, num_classes, height, width]
         and predictive uncertainty [batch_size, height, width]
     """
+    if task == "multilabel":
+        mean = aggregate_fn(torch.sigmoid(logits), dim=-1)
+        mean = mean.clamp(eps, 1 - eps)
+        entropy = -(mean * mean.log() + (1 - mean) * (1 - mean).log()).sum(dim=1)
+        return {"pred": mean, "pred_uct": entropy, "logits": logits}
+
     mean = aggregate_fn(nn.functional.softmax(logits, dim=1), dim=-1)
     # prevent log of 0 -> nan
     mean.clamp_min_(eps)
@@ -273,16 +338,24 @@ def save_regression_predictions(outputs: dict[str, Tensor], path: str) -> None:
         df.to_csv(path, index=False)
 
 
-def save_classification_predictions(outputs: dict[str, Tensor], path: str) -> None:
+def save_classification_predictions(
+    outputs: dict[str, Tensor], path: str, task: str = "multiclass"
+) -> None:
     """Save classification predictions to csv file.
+
+    For the "multilabel" task the labels are not mutually exclusive, so instead
+    of a single ``pred`` column there is one ``pred_i`` column per label,
+    holding the thresholded prediction for that label.
 
     Args:
         outputs: metrics and values to be saved
             - logits: logits of shape [batch_size, num_classes]
             - pred: predictions of shape [batch_size, num_classes]
-            - target: targets of shape [batch_size]
+            - target: targets of shape [batch_size], or [batch_size, num_labels]
+              for the "multilabel" task
             - pred_uct: predictive uncertainty of shape [batch_size]
         path: path where csv should be saved
+        task: one of "binary", "multiclass" or "multilabel"
     """
     if "samples" in outputs:
         _ = outputs.pop("samples")
@@ -299,7 +372,6 @@ def save_classification_predictions(outputs: dict[str, Tensor], path: str) -> No
 
     # save inidividual predictions as class probs
     class_probs = outputs.pop("pred")
-    pred_class = torch.argmax(class_probs, dim=1).cpu().numpy()
 
     for i in range(class_probs.shape[1]):
         outputs[f"class_prob_{i}"] = class_probs[:, i]
@@ -307,11 +379,24 @@ def save_classification_predictions(outputs: dict[str, Tensor], path: str) -> No
     cpu_outputs = {}
     for key, val in outputs.items():
         if isinstance(val, Tensor):
-            cpu_outputs[key] = val.squeeze(-1).cpu().numpy()
+            val = val.squeeze(-1).cpu().numpy()
         else:
-            cpu_outputs[key] = np.array(val)
+            val = np.array(val)
+        # per-label targets and the like need one column each
+        if val.ndim == 2:
+            for i in range(val.shape[1]):
+                cpu_outputs[f"{key}_{i}"] = val[:, i]
+        else:
+            cpu_outputs[key] = val
 
-    df_pred = pd.DataFrame(pred_class, columns=["pred"])
+    if task == "multilabel":
+        preds = (class_probs > 0.5).int().cpu().numpy()
+        df_pred = pd.DataFrame(
+            preds, columns=[f"pred_{i}" for i in range(preds.shape[1])]
+        )
+    else:
+        pred_class = torch.argmax(class_probs, dim=1).cpu().numpy()
+        df_pred = pd.DataFrame(pred_class, columns=["pred"])
 
     # Create DataFrame for the rest of the outputs
     df_outputs = pd.DataFrame.from_dict(cpu_outputs)

--- a/lightning_uq_box/uq_methods/zigzag.py
+++ b/lightning_uq_box/uq_methods/zigzag.py
@@ -294,7 +294,7 @@ class ZigZagClassification(ZigZagBase):
 
     pred_file_name = "preds.csv"
 
-    valid_tasks = ["binary", "multiclass", "multilable"]
+    valid_tasks = ["binary", "multiclass", "multilabel"]
 
     def __init__(
         self,
@@ -375,5 +375,7 @@ class ZigZagClassification(ZigZagBase):
             dataloader_idx: dataloader index
         """
         save_classification_predictions(
-            outputs, os.path.join(self.trainer.default_root_dir, self.pred_file_name)
+            outputs,
+            os.path.join(self.trainer.default_root_dir, self.pred_file_name),
+            task=self.task,
         )

--- a/tests/uq_methods/test_classification.py
+++ b/tests/uq_methods/test_classification.py
@@ -7,15 +7,24 @@ import os
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 import pytest
+import torch
+import torch.nn as nn
 from conftest import minimal_cli_overrides, minimal_trainer_kwargs
-from lightning import Trainer
+from lightning import LightningDataModule, Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
 from pytest import TempPathFactory
+from torch import Tensor
+from torch.utils.data import DataLoader, Dataset
 
 from lightning_uq_box.datamodules import TwoMoonsDataModule
 from lightning_uq_box.main import get_uq_box_cli
-from lightning_uq_box.uq_methods import DeepEnsembleClassification
+from lightning_uq_box.models import MLP
+from lightning_uq_box.uq_methods import (
+    DeepEnsembleClassification,
+    DeterministicClassification,
+)
 
 model_config_paths = [
     "tests/configs/classification/mc_dropout.yaml",
@@ -183,3 +192,57 @@ class TestFrozenBackbone:
             assert not all(
                 [param.requires_grad for param in model.feature_extractor.parameters()]
             )
+
+
+class ToyMultilabelDataset(Dataset):
+    """Toy multilabel dataset with multi-hot targets."""
+
+    def __init__(self, n_samples: int = 16, n_labels: int = 3) -> None:
+        generator = torch.Generator().manual_seed(0)
+        self.inputs = torch.randn(n_samples, 2, generator=generator)
+        self.targets = (
+            torch.rand(n_samples, n_labels, generator=generator) > 0.5
+        ).float()
+
+    def __len__(self) -> int:
+        return len(self.inputs)
+
+    def __getitem__(self, index: int) -> dict[str, Tensor]:
+        return {"input": self.inputs[index], "target": self.targets[index]}
+
+
+class ToyMultilabelDataModule(LightningDataModule):
+    """Toy multilabel datamodule with multi-hot targets."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.dataset = ToyMultilabelDataset()
+
+    def _dataloader(self) -> DataLoader:
+        return DataLoader(self.dataset, batch_size=4)
+
+    train_dataloader = _dataloader
+    val_dataloader = _dataloader
+    test_dataloader = _dataloader
+
+
+class TestMultilabelClassification:
+    def test_trainer(self, tmp_path: Path, accelerator_config: dict) -> None:
+        """A multilabel run trains, tests and saves per-label predictions."""
+        model = DeterministicClassification(
+            MLP(n_inputs=2, n_outputs=3, n_hidden=[8]),
+            nn.BCEWithLogitsLoss(),
+            task="multilabel",
+        )
+        datamodule = ToyMultilabelDataModule()
+        trainer = Trainer(**minimal_trainer_kwargs(accelerator_config, tmp_path))
+
+        trainer.fit(model, datamodule)
+        trainer.test(model, datamodule=datamodule)
+
+        df = pd.read_csv(os.path.join(tmp_path, model.pred_file_name))
+        assert "pred" not in df.columns
+        for i in range(3):
+            assert set(df[f"pred_{i}"].unique()) <= {0, 1}
+            assert f"class_prob_{i}" in df.columns
+            assert f"target_{i}" in df.columns

--- a/tests/uq_methods/test_utils.py
+++ b/tests/uq_methods/test_utils.py
@@ -13,6 +13,9 @@ from conftest import minimal_cli_overrides
 from lightning_uq_box.main import get_uq_box_cli
 from lightning_uq_box.uq_methods.utils import (
     checkpoint_loader,
+    default_classification_metrics,
+    default_segmentation_metrics,
+    process_classification_prediction,
     save_classification_predictions,
 )
 
@@ -87,6 +90,75 @@ def test_save_classification_predictions(tmp_path: Path) -> None:
     df = pd.read_csv(path)
     assert df["pred"].tolist() == [2, 0]
     for i in range(class_probs.shape[1]):
+        assert df[f"class_prob_{i}"].tolist() == pytest.approx(
+            class_probs[:, i].tolist()
+        )
+
+
+# "binary" is left out: EmpiricalCoverage needs a [batch_size, num_classes]
+# prediction tensor while BinaryAccuracy needs one shaped like the target, so the
+# binary metric set cannot be updated with a single prediction tensor. That is a
+# pre-existing incompatibility, unrelated to multilabel support.
+@pytest.mark.parametrize("task", ["multiclass", "multilabel"])
+def test_default_classification_metrics(task: str) -> None:
+    """The default metrics construct and update for every supported task."""
+    num_classes = 4
+    metrics = default_classification_metrics("test", task, num_classes)
+
+    preds = torch.rand(8, num_classes)
+    if task == "multiclass":
+        target = torch.randint(0, num_classes, (8,))
+    else:
+        target = torch.randint(0, 2, (8, num_classes))
+
+    assert metrics(preds, target)
+
+
+@pytest.mark.parametrize("task", ["binary", "multiclass", "multilabel"])
+def test_default_segmentation_metrics(task: str) -> None:
+    """The default metrics construct and update for every supported task."""
+    num_classes = 1 if task == "binary" else 4
+    metrics = default_segmentation_metrics("test", task, num_classes)
+
+    preds = (
+        torch.rand(2, 4, 4) if task == "binary" else torch.rand(2, num_classes, 4, 4)
+    )
+    if task == "multiclass":
+        target = torch.randint(0, num_classes, (2, 4, 4))
+    elif task == "binary":
+        target = torch.randint(0, 2, (2, 4, 4))
+    else:
+        target = torch.randint(0, 2, (2, num_classes, 4, 4))
+
+    assert metrics(preds, target)
+
+
+def test_process_classification_prediction_multilabel() -> None:
+    """Multilabel probabilities are per label and need not sum to one."""
+    logits = torch.tensor([[2.0, 2.0, 2.0], [-2.0, -2.0, -2.0]]).unsqueeze(-1)
+
+    out = process_classification_prediction(logits, task="multilabel")
+
+    assert out["pred"].shape == (2, 3)
+    assert torch.allclose(out["pred"], torch.sigmoid(logits[..., 0]))
+    assert out["pred_uct"].shape == (2,)
+
+
+def test_save_classification_predictions_multilabel(tmp_path: Path) -> None:
+    """Multilabel predictions are saved as one thresholded column per label."""
+    class_probs = torch.tensor([[0.1, 0.8, 0.7], [0.6, 0.3, 0.1]])
+    target = torch.tensor([[0, 1, 1], [1, 0, 0]])
+    path = str(tmp_path / "preds.csv")
+
+    save_classification_predictions(
+        {"pred": class_probs.clone(), "target": target}, path, task="multilabel"
+    )
+
+    df = pd.read_csv(path)
+    assert "pred" not in df.columns
+    for i in range(class_probs.shape[1]):
+        assert df[f"pred_{i}"].tolist() == (class_probs[:, i] > 0.5).int().tolist()
+        assert df[f"target_{i}"].tolist() == target[:, i].tolist()
         assert df[f"class_prob_{i}"].tolist() == pytest.approx(
             class_probs[:, i].tolist()
         )


### PR DESCRIPTION
`multilabel` is listed in `valid_tasks` and in the docstrings of every classification method, but it never worked. 11 classes spelled it `"multilable"`, so `task="multilabel"` failed the `valid_tasks` assertion; the two that spelled it correctly (`DeepEnsembleClassification`, `SGLDClassification`) failed later instead.

Fixing the typo alone is not enough — the typo was masking an unimplemented feature — so this makes the pieces behind it work:

- **Metrics.** `default_classification_metrics` / `default_segmentation_metrics` pass `num_labels` instead of `num_classes` for the multilabel task, which torchmetrics requires (`Accuracy(task="multilabel", num_classes=4)` raises ``` `num_labels` must be int ```). `CalibrationError` has no multilabel variant at all, and `EmpiricalCoverage` is defined in terms of a single true label per sample, so the multilabel metric set is Accuracy + F1Score.
- **Predictions.** `process_classification_prediction` / `process_segmentation_prediction` apply a sigmoid per label instead of a softmax over labels, and report the summed per-label binary entropy as the predictive uncertainty. `task` is threaded through from the calling method (`task=self.task`), so nothing changes for binary/multiclass.
- **Saved CSVs.** `save_classification_predictions` writes one thresholded `pred_i` column per label instead of an argmax `pred` column, and expands two-dimensional values such as multi-hot targets into one column per label — `pd.DataFrame.from_dict` rejects 2-d arrays, so multilabel saving would otherwise crash.

## Tests

Five new tests, all of which fail before this change:

- `default_classification_metrics` / `default_segmentation_metrics` construct **and update** for each task.
- `process_classification_prediction` returns per-label sigmoid probabilities that need not sum to one.
- `save_classification_predictions` writes `pred_i` / `target_i` / `class_prob_i` columns for multilabel.
- an end-to-end multilabel fit + test run through `DeterministicClassification` that reads the saved CSV back.

`pytest tests/ -m 'not slow'`: 413 passed. `ruff check`, `ruff format --check`, `ty check` clean.

## Notes

- The `binary` task is left out of the metric-update test: `EmpiricalCoverage` needs a `[batch_size, num_classes]` prediction tensor while `BinaryAccuracy` needs one shaped like the target, so the binary metric set cannot be updated with a single prediction tensor. That is a pre-existing incompatibility, unrelated to this change, and is called out in a comment next to the test.
- `RAPS` keeps `multilabel` in its `valid_tasks` for consistency with the other methods; conformal set prediction over non-exclusive labels is a separate question and is not addressed here.