### PR TITLE
Clear call-non-callable in uq_methods

### DIFF
--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -12,6 +12,7 @@ from lightning import LightningModule
 from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from omegaconf import OmegaConf
 from torch import Tensor
+from torchmetrics import MetricCollection
 
 from .utils import (
     _get_num_inputs,
@@ -41,6 +42,13 @@ class BaseModule(LightningModule):
 
     input_key = "input"
     target_key = "target"
+
+    # Assigned by each subclass, usually in setup_task(). Declared here so they read as
+    # MetricCollections rather than through nn.Module.__getattr__, which returns
+    # `Tensor | Module`, and so the contract on subclasses is stated in one place.
+    train_metrics: MetricCollection
+    val_metrics: MetricCollection
+    test_metrics: MetricCollection
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize a new instance of the Base Module."""

--- a/lightning_uq_box/uq_methods/bnn_lv_vi.py
+++ b/lightning_uq_box/uq_methods/bnn_lv_vi.py
@@ -41,6 +41,9 @@ class BNN_LV_VI_Base(BNN_VI_Base):
 
     """
 
+    # set as a class attribute by the concrete subclasses
+    nll_loss: nn.GaussianNLLLoss
+
     lv_intro_options = ["first", "last"]
 
     def __init__(
@@ -284,6 +287,7 @@ class BNN_LV_VI_Base(BNN_VI_Base):
                 [X, z], -1
             )  # [batch_size, num_dataset_features+lv_latent_dim]
             X = self.model(X)
+            assert self.prediction_head is not None
             X = self.prediction_head(X)
         else:
             X = self.model(X)
@@ -299,6 +303,7 @@ class BNN_LV_VI_Base(BNN_VI_Base):
             X = torch.cat(
                 [X, z], -1
             )  # [batch_size, model output_features+lv_latent_dim]
+            assert self.prediction_head is not None
             X = self.prediction_head(X)
 
         return X
@@ -315,7 +320,7 @@ class BNN_LV_VI_Base(BNN_VI_Base):
         batch_size = X.shape[0]
         return torch.randn(batch_size, self.hparams.lv_latent_dim, device=X.device)
 
-    def compute_energy_loss(self, X: Tensor, y: Tensor) -> tuple[Tensor]:
+    def compute_energy_loss(self, X: Tensor, y: Tensor) -> tuple[Tensor, Tensor]:
         """Compute the loss for BNN with alpha divergence.
 
         Args:
@@ -662,7 +667,7 @@ class BNN_LV_VI_Batched_Base(BNN_LV_VI_Base):
             num_samples, batch_size, self.hparams.lv_latent_dim, device=X.device
         ).to(self.device)
 
-    def compute_energy_loss(self, X: Tensor, y: Tensor) -> tuple[Tensor]:
+    def compute_energy_loss(self, X: Tensor, y: Tensor) -> tuple[Tensor, Tensor]:
         """Compute the loss for BNN with alpha divergence.
 
         Args:

--- a/lightning_uq_box/uq_methods/bnn_vi.py
+++ b/lightning_uq_box/uq_methods/bnn_vi.py
@@ -204,6 +204,10 @@ class BNN_VI_Base(DeterministicModel):
             if "Variational" in module.__class__.__name__:
                 module.unfreeze_layer()
 
+    def compute_energy_loss(self, X: Tensor, y: Tensor) -> tuple[Tensor, Tensor]:
+        """Compute the energy loss and mean output for a batch."""
+        raise NotImplementedError
+
     def exclude_from_wt_decay(
         self,
         named_params,
@@ -361,7 +365,7 @@ class BNN_VI_Regression(BNN_VI_Base):
         self.val_metrics = default_regression_metrics("val")
         self.test_metrics = default_regression_metrics("test")
 
-    def compute_energy_loss(self, X: Tensor, y: Tensor) -> None:
+    def compute_energy_loss(self, X: Tensor, y: Tensor) -> tuple[Tensor, Tensor]:
         """Compute the loss for BNN with alpha divergence.
 
         Args:
@@ -553,7 +557,7 @@ class BNN_VI_BatchedRegression(BNN_VI_Regression):
         batched_sample_X = einops.repeat(X, "b f -> s b f", s=n_samples)
         return self.model(batched_sample_X)
 
-    def compute_energy_loss(self, X: Tensor, y: Tensor) -> tuple[Tensor]:
+    def compute_energy_loss(self, X: Tensor, y: Tensor) -> tuple[Tensor, Tensor]:
         """Compute the loss for BNN with alpha divergence.
 
         Args:

--- a/lightning_uq_box/uq_methods/cards.py
+++ b/lightning_uq_box/uq_methods/cards.py
@@ -142,7 +142,9 @@ class CARDBase(BaseModule):
         )
 
         if self.use_ema_model:
-            guidance_output = self.ema.ema_model(x, y_t_sample, y_0_hat, ant_samples_t)
+            ema_model = self.ema.ema_model
+            assert ema_model is not None
+            guidance_output = ema_model(x, y_t_sample, y_0_hat, ant_samples_t)
         else:
             guidance_output = self.guidance_model(x, y_t_sample, y_0_hat, ant_samples_t)
 
@@ -334,7 +336,9 @@ class CARDBase(BaseModule):
             alpha_t.sqrt() + sqrt_alpha_bar_t_m_1
         ) / (sqrt_one_minus_alpha_bar_t.square())
         if self.use_ema_model:
-            eps_theta = self.ema.ema_model(x, y, y_0_hat, t).detach()
+            ema_model = self.ema.ema_model
+            assert ema_model is not None
+            eps_theta = ema_model(x, y, y_0_hat, t).detach()
         else:
             eps_theta = self.guidance_model(x, y, y_0_hat, t).detach()
         # y_0 reparameterization
@@ -387,7 +391,9 @@ class CARDBase(BaseModule):
         sqrt_one_minus_alpha_bar_t = self.extract(one_minus_alphas_bar_sqrt, t, y)
         sqrt_alpha_bar_t = (1 - sqrt_one_minus_alpha_bar_t.square()).sqrt()
         if self.use_ema_model:
-            eps_theta = self.ema.ema_model(x, y, y_0_hat, t).detach()
+            ema_model = self.ema.ema_model
+            assert ema_model is not None
+            eps_theta = ema_model(x, y, y_0_hat, t).detach()
         else:
             eps_theta = self.guidance_model(x, y, y_0_hat, t).detach()
         # y_0 reparameterization

--- a/lightning_uq_box/uq_methods/conformal_qr.py
+++ b/lightning_uq_box/uq_methods/conformal_qr.py
@@ -107,8 +107,8 @@ class ConformalQR(PosthocBase):
             )
 
         with torch.no_grad():
-            if hasattr(self.model, "predict_step"):
-                pred = self.model.predict_step(X)
+            if callable(predict_step := getattr(self.model, "predict_step", None)):
+                pred = predict_step(X)
             else:
                 pred = self.model(X)
 

--- a/lightning_uq_box/uq_methods/deep_ensemble.py
+++ b/lightning_uq_box/uq_methods/deep_ensemble.py
@@ -7,7 +7,6 @@ import os
 from typing import Any
 
 import torch
-from lightning import LightningModule
 from torch import Tensor
 
 from .base import BaseModule
@@ -33,9 +32,7 @@ class DeepEnsemble(BaseModule):
     * https://proceedings.neurips.cc/paper_files/paper/2017/hash/9ef2ed4b7fd2c810847ffa5fa85bce38-Abstract.html # noqa: E501
     """
 
-    def __init__(
-        self, ensemble_members: list[dict[str, type[LightningModule] | str]]
-    ) -> None:
+    def __init__(self, ensemble_members: list[dict[str, Any]]) -> None:
         """Initialize a new instance of DeepEnsembleModel Wrapper.
 
         Args:
@@ -174,7 +171,7 @@ class DeepEnsembleClassification(DeepEnsemble):
 
     def __init__(
         self,
-        ensemble_members: list[dict[str, type[LightningModule] | str]],
+        ensemble_members: list[dict[str, Any]],
         num_classes: int,
         task: str = "multiclass",
     ) -> None:
@@ -242,7 +239,7 @@ class DeepEnsembleSegmentation(DeepEnsembleClassification):
 
     def __init__(
         self,
-        ensemble_members: list[dict[str, type[LightningModule] | str]],
+        ensemble_members: list[dict[str, Any]],
         num_classes: int,
         task: str = "multiclass",
         save_preds: bool = False,
@@ -319,9 +316,7 @@ class DeepEnsemblePxRegression(DeepEnsembleRegression):
     """  # noqa: E501
 
     def __init__(
-        self,
-        ensemble_members: list[dict[str, type[LightningModule] | str]],
-        save_preds: bool = False,
+        self, ensemble_members: list[dict[str, Any]], save_preds: bool = False
     ) -> None:
         """Initialize a new instance of DeepEnsemble for Pixelwise Regression.
 

--- a/lightning_uq_box/uq_methods/deep_kernel_learning.py
+++ b/lightning_uq_box/uq_methods/deep_kernel_learning.py
@@ -46,6 +46,12 @@ class DKLBase(gpytorch.Module, BaseModule):
     * https://proceedings.mlr.press/v51/wilson16.html
     """
 
+    # Assigned by _build_model() in the subclasses. Declared here so they do not read
+    # through nn.Module.__getattr__, which returns `Tensor | Module`.
+    gp_layer: "DKLGPLayer"
+    scale_to_bounds: ScaleToBounds
+    elbo_fn: VariationalELBO
+
     # TODO make elbo_fn an argument that can be instatiated with
     # different elbo functions and Lightning CLI
     kernel_choices = ["RBF", "Matern12", "Matern32", "Matern52", "RQ"]
@@ -114,6 +120,10 @@ class DKLBase(gpytorch.Module, BaseModule):
         """
         return self.gp_layer.n_outputs
 
+    def _build_model(self) -> None:
+        """Build the feature extractor and GP layer."""
+        raise NotImplementedError
+
     def setup_task(self) -> None:
         """Set up task specific attributes."""
         raise NotImplementedError
@@ -177,7 +187,9 @@ class DKLBase(gpytorch.Module, BaseModule):
         X, y = batch[self.input_key], batch[self.target_key]
 
         y_pred = self.forward(X)
-        loss = -self.elbo_fn(y_pred, y.squeeze(-1)).mean()
+        elbo = self.elbo_fn(y_pred, y.squeeze(-1))
+        assert isinstance(elbo, Tensor)
+        loss = -elbo.mean()
 
         self.log(
             "train_loss", loss, batch_size=batch[self.input_key].shape[0]
@@ -215,7 +227,9 @@ class DKLBase(gpytorch.Module, BaseModule):
         else:
             y_pred = self.forward(X)
 
-        loss = -self.elbo_fn(y_pred, y.squeeze(-1)).mean()
+        elbo = self.elbo_fn(y_pred, y.squeeze(-1))
+        assert isinstance(elbo, Tensor)
+        loss = -elbo.mean()
 
         self.log(
             "val_loss", loss, batch_size=batch[self.input_key].shape[0]
@@ -528,7 +542,9 @@ class DKLClassification(DKLBase):
         X, y = batch[self.input_key], batch[self.target_key]
 
         y_pred = self.forward(X)
-        loss = -self.elbo_fn(y_pred, y.squeeze(-1)).mean()
+        elbo = self.elbo_fn(y_pred, y.squeeze(-1))
+        assert isinstance(elbo, Tensor)
+        loss = -elbo.mean()
 
         self.log(
             "train_loss", loss, batch_size=batch[self.input_key].shape[0]
@@ -560,7 +576,9 @@ class DKLClassification(DKLBase):
         else:
             y_pred = self.forward(X)
 
-        loss = -self.elbo_fn(y_pred, y.squeeze(-1)).mean()
+        elbo = self.elbo_fn(y_pred, y.squeeze(-1))
+        assert isinstance(elbo, Tensor)
+        loss = -elbo.mean()
 
         self.log(
             "val_loss", loss, batch_size=batch[self.input_key].shape[0]

--- a/lightning_uq_box/uq_methods/density_uncertainty.py
+++ b/lightning_uq_box/uq_methods/density_uncertainty.py
@@ -175,8 +175,9 @@ class DensityLayerModelBase(DeterministicModel):
         """Compute the KL divergence of the model."""
         kl_loss = []
         for layer in self.modules():
-            if hasattr(layer, "compute_kl_div"):
-                kl_loss.append(layer.compute_kl_div())
+            layer_kl_div = getattr(layer, "compute_kl_div", None)
+            if callable(layer_kl_div):
+                kl_loss.append(layer_kl_div())
         return sum(kl_loss)
 
     def gather_loglikelihood(self) -> Tensor:

--- a/lightning_uq_box/uq_methods/img2img_conformal.py
+++ b/lightning_uq_box/uq_methods/img2img_conformal.py
@@ -105,8 +105,8 @@ class Img2ImgConformal(PosthocBase):
             model output tensor of shape [batch_size x num_outputs]
         """
         with torch.no_grad():
-            if hasattr(self.model, "predict_step"):
-                pred = self.model.predict_step(X)
+            if callable(predict_step := getattr(self.model, "predict_step", None)):
+                pred = predict_step(X)
                 pred = torch.stack([pred["lower"], pred["pred"], pred["upper"]], dim=1)
             else:
                 pred = self.model(X).squeeze(2)

--- a/lightning_uq_box/uq_methods/inference_time_augmentation.py
+++ b/lightning_uq_box/uq_methods/inference_time_augmentation.py
@@ -141,8 +141,8 @@ class TTABase(PosthocBase):
         def yield_prediction(X: Tensor) -> Tensor | dict[str, Tensor]:
             """Yield prediction depending on underlying model."""
             with torch.no_grad():
-                if hasattr(self.model, "predict_step"):
-                    pred = self.model.predict_step(X)
+                if callable(predict_step := getattr(self.model, "predict_step", None)):
+                    pred = predict_step(X)
                 else:
                     pred = self.model(X)
             return pred

--- a/lightning_uq_box/uq_methods/laplace_model.py
+++ b/lightning_uq_box/uq_methods/laplace_model.py
@@ -8,6 +8,7 @@ import os
 from typing import Any
 
 import torch
+import torch.nn as nn
 from laplace import Laplace
 from torch import Tensor
 from tqdm import trange
@@ -81,6 +82,9 @@ class LaplaceBase(BaseModule):
     """
 
     pred_file_name = "preds.csv"
+
+    # assigned by the concrete subclasses
+    loss_fn: nn.Module
 
     def __init__(
         self,

--- a/lightning_uq_box/uq_methods/raps.py
+++ b/lightning_uq_box/uq_methods/raps.py
@@ -152,8 +152,8 @@ class RAPS(PosthocBase):
         # need to set manually because of inference mode
         self.eval()
         with torch.no_grad():
-            if hasattr(self.model, "predict_step"):
-                logits = self.model.predict_step(X)["logits"]
+            if callable(predict_step := getattr(self.model, "predict_step", None)):
+                logits = predict_step(X)["logits"]
             else:
                 logits = self.model(X)
             # temp scale logits just for prediction processing

--- a/lightning_uq_box/uq_methods/sngp.py
+++ b/lightning_uq_box/uq_methods/sngp.py
@@ -109,6 +109,10 @@ class SNGPBase(BaseModule):
 
         self.setup_task()
 
+    def setup_task(self) -> None:
+        """Set up task specific attributes."""
+        raise NotImplementedError
+
     def _build_model(self) -> None:
         """Build SNGP model."""
         if self.num_gp_features > 0:

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -467,8 +467,9 @@ def freeze_model_backbone(model: nn.Module) -> None:
         param.requires_grad = False
 
     # for timm model
-    if hasattr(model, "get_classifier"):
-        for param in model.get_classifier().parameters():
+    get_classifier = getattr(model, "get_classifier", None)
+    if callable(get_classifier):
+        for param in get_classifier().parameters():
             param.requires_grad = True
     else:
         # find last layer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,6 @@ include = ["lightning_uq_box/uq_methods"]
 # `self.hparams.<name>` read is unresolved. torchgeo mutes this rule globally.
 unresolved-attribute = "ignore"
 # TODO: fix and delete, one family per PR.
-call-non-callable = "ignore"
 empty-body = "ignore"
 index-out-of-bounds = "ignore"
 invalid-argument-type = "ignore"


### PR DESCRIPTION
Third step of the ty rollout, after #495 put `uq_methods` behind a `[[tool.ty.overrides]]` block. This clears all **83 `call-non-callable`** and deletes that rule from the block.

### One cause again: contracts the base classes never stated

Every one of them was an attribute or method used by a base class but only provided by its subclasses. With no class-level declaration, `nn.Module.__getattr__` types the attribute as `Tensor | Module`, and calling it is an error. Stating the contract on the base is the fix, and it documents what subclasses are already required to provide:

- **`BaseModule` declares `train_metrics` / `val_metrics` / `test_metrics` as `MetricCollection`.** That alone was 60 of the 83 — `DeterministicModel` uses them in nine places and never assigns them.
- `DKLBase` declares `gp_layer`, `scale_to_bounds` and `elbo_fn`, built by `_build_model()` in the subclasses, and gets an abstract `_build_model`.
- `SNGPBase` gets an abstract `setup_task`, `BNN_VI_Base` an abstract `compute_energy_loss`, `BNN_LV_VI_Base` declares `nll_loss`, `LaplaceBase` declares `loss_fn`.

Adding the `compute_energy_loss` stub exposed that the three implementations annotate their return as `tuple[Tensor]` (and one as `None`) while all three return **two** tensors — which is also what the call sites unpack. Corrected to `tuple[Tensor, Tensor]`.

### The rest

- Four `if hasattr(self.model, "predict_step")` guards, plus the two module loops in `density_uncertainty` and `utils`, bind the attribute with `getattr` and test `callable()`; ty cannot narrow through `hasattr`. A non-callable attribute of that name now falls to the `else` branch instead of raising.
- gpytorch types `Module.__call__` as `Tensor | Distribution | LinearOperator`. `VariationalELBO` returns a `Tensor`, so the four elbo call sites assert that before taking `.mean()`.
- `ema_pytorch` initialises `EMA.ema_model` to `None` and builds it lazily, so its declared type stays Optional. The three CARD call sites assert it is built.
- `bnn_lv_vi` asserts `prediction_head` is set on the two paths that call it; it is Optional on the base and filled in by `_define_bnn_args`.
- `DeepEnsemble` annotated `ensemble_members` as `list[dict[str, type[LightningModule] | str]]`, but the dicts hold model *instances*, not classes. `list[dict[str, Any]]` is honest about the heterogeneous values. A `TypedDict` would be more precise, but plain dict literals are not assignable to one, so it would break every caller — worth considering separately.

### A prediction that did not hold

I expected this to take a large share of `invalid-argument-type` with it, as the same fix did in `models` (#494). It barely moved: **110 → 103**. In `models` the `Tensor | Module` union mostly surfaced as bad argument types; here it lands almost entirely on `call-non-callable`. So `invalid-argument-type` is its own piece of work, not a by-product of this one.

### What is left behind the mutes

| rule | count |
| --- | --- |
| `invalid-argument-type` | 103 |
| `invalid-method-override` | 87 |
| `invalid-return-type` | 37 |
| `invalid-assignment` | 18 |
| `unsupported-operator` | 14 |
| the tail (7 rules) | 26 |

### Verification

`ruff check`/`format`, `ty check` (0 diagnostics), `pytest` (405 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdrE6md5VsMgFNR3MLiEjY
