### PR TITLE
Remove dead code and align naming in uq_methods

### DIFF
--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -22,6 +22,7 @@ from .utils import (
     default_segmentation_metrics,
     freeze_model_backbone,
     freeze_segmentation_model,
+    identity,
     process_classification_prediction,
     process_segmentation_prediction,
     save_classification_predictions,
@@ -395,9 +396,6 @@ class DeterministicClassification(DeterministicModel):
         with torch.no_grad():
             out = self.forward(X)
 
-        def identity(x, dim=None):
-            return x
-
         return process_classification_prediction(
             out, aggregate_fn=identity, task=self.task
         )
@@ -493,9 +491,6 @@ class DeterministicSegmentation(DeterministicClassification):
         """
         with torch.no_grad():
             out = self.forward(X)
-
-        def identity(x, dim=None):
-            return x
 
         return process_segmentation_prediction(
             out, aggregate_fn=identity, task=self.task

--- a/lightning_uq_box/uq_methods/deep_kernel_learning.py
+++ b/lightning_uq_box/uq_methods/deep_kernel_learning.py
@@ -492,10 +492,6 @@ class DKLClassification(DKLBase):
             "test", self.task, self.num_classes
         )
 
-    def _adapt_output_for_metrics(self, output: MultivariateNormal) -> Tensor:
-        """Adapt model output to be compatible for metric computation.."""
-        return output.mean
-
     def _build_model(self) -> None:
         """Build the model ready for training."""
         self.gp_layer = DKLGPLayer(

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -36,13 +36,6 @@ def find_dropout_layers(model: nn.Module) -> list[str]:
         if isinstance(module, nn.Dropout):
             dropout_layers.append(name)
 
-    # if not dropout_layers:
-    #     raise UserWarning(
-    #         (
-    #           "No dropout layers found in model, maybe dropout "
-    #           "is implemented through nn.fucntional?"
-    #         )
-    #     )
     return dropout_layers
 
 

--- a/lightning_uq_box/uq_methods/raps.py
+++ b/lightning_uq_box/uq_methods/raps.py
@@ -28,7 +28,11 @@ from torchmetrics import Accuracy, CalibrationError, MetricCollection
 from .base import PosthocBase
 from .metrics import EmpiricalCoverage, SetSize
 from .temp_scaling import run_temperature_optimization, temp_scale_logits
-from .utils import process_classification_prediction, save_classification_predictions
+from .utils import (
+    identity,
+    process_classification_prediction,
+    save_classification_predictions,
+)
 
 
 class RAPS(PosthocBase):
@@ -165,10 +169,6 @@ class RAPS(PosthocBase):
         if logits.ndim == 3:
             agg_func = torch.mean
         else:
-
-            def identity(x, dim=None):
-                return x
-
             agg_func = identity
 
         pred_dict = process_classification_prediction(

--- a/lightning_uq_box/uq_methods/sgld.py
+++ b/lightning_uq_box/uq_methods/sgld.py
@@ -251,7 +251,7 @@ class SGLDRegression(SGLDBase):
         )  # logging to Logger
         self.train_metrics(self.adapt_output_for_metrics(out), y)
 
-        # return loss
+        return loss
 
     def predict_step(
         self, X: Tensor, batch_idx: int = 0, dataloader_idx: int = 0

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -59,6 +59,22 @@ def checkpoint_loader(
         return model_class
 
 
+def identity(x: Tensor, dim: int | None = None) -> Tensor:
+    """Return the input unchanged.
+
+    Used as the aggregation function when there is no sample dimension to
+    aggregate over.
+
+    Args:
+        x: input tensor
+        dim: unused, accepted to match the aggregation function signature
+
+    Returns:
+        the input tensor
+    """
+    return x
+
+
 def default_regression_metrics(prefix: str):
     """Return a set of default regression metrics."""
     return MetricCollection(


### PR DESCRIPTION
Four leftovers found while reading through the methods. None of them change behaviour.

- **`DKLClassification._adapt_output_for_metrics` is dead.** It was renamed from `_extract_mean_output` in #81 and was already unused then. `DKLBase` computes metric inputs inline from `y_pred.mean`, and `DKLClassification` overrides `training_step`/`validation_step` to use `self.likelihood(y_pred).probs.mean(0)`, so nothing calls it. The leading underscore also meant it could never have overridden the `adapt_output_for_metrics` hook that the other modules define — I checked the history to see whether it was meant to be wired up, and it never was.
- **Commented-out `raise UserWarning` block in `find_dropout_layers`** — dropped rather than restored as live code; a hard failure when a model uses `nn.functional.dropout` would be a behaviour change, and this PR is meant to be inert.
- **`identity` aggregation closure was redefined in three places** (`DeterministicClassification.predict_step`, `DeterministicSegmentation.predict_step`, `RAPS.predict_step`). Now one module-level helper in `utils`.
- **`SGLDRegression.training_step` ended on a commented-out `# return loss`** while `SGLDClassification` returns it. SGLD sets `automatic_optimization = False`, so Lightning ignores the return value either way — this is a readability fix, not a bug fix.

`pytest tests/ -m 'not slow'`: 405 passed. `ruff check`, `ruff format --check`, `ty check` clean.