### PR TITLE
Add a release workflow that publishes to PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,66 @@
+name: release
+on:
+  release:
+    types:
+    - published
+  workflow_dispatch:
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repo
+      uses: actions/checkout@v7
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v10.0.1
+      with:
+        python-version: '3.12'
+        enable-cache: true
+        prune-cache: true
+        activate-environment: true
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+    - name: Check that the tag matches the project version
+      if: github.event_name == 'release'
+      run: |
+        version=$(uv version --short)
+        tag=${GITHUB_REF_NAME#v}
+        if [ "$version" != "$tag" ]; then
+          echo "tag $GITHUB_REF_NAME does not match pyproject.toml version $version" >&2
+          exit 1
+        fi
+    - name: Build sdist and wheel
+      run: uv build
+    - name: Check the distributions
+      run: uvx twine check --strict dist/*
+    - name: Upload the distributions
+      uses: actions/upload-artifact@v7
+      with:
+        name: dist
+        path: dist/
+  publish:
+    name: publish
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      # Required for trusted publishing to PyPI
+      id-token: write
+    steps:
+    - name: Download the distributions
+      uses: actions/download-artifact@v8
+      with:
+        name: dist
+        path: dist/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
     - main
+    - release**
   pull_request:
     branches:
     - main
+    - release**
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Groundwork for the 0.3.0 release. No behavior change to the package itself.

- `release.yaml`: a published GitHub Release builds the sdist and wheel with `uv build`, checks them with `twine check --strict`, and uploads to PyPI via trusted publishing (OIDC, `environment: pypi`, no token anywhere). `workflow_dispatch` runs the build job only, as a dry run.
- The build job fails if the tag does not match `[project] version` in `pyproject.toml`, which since the uv migration is the only place the version is declared.
- `tests.yaml` now also runs on `release**` branches, which `style.yaml` already did.

Before the first real release I still need to register the trusted publisher on PyPI (`lightning-uq-box`, workflow `release.yaml`, environment `pypi`) and create the `pypi` environment on this repo.

Verified locally: `uv build` produces `lightning_uq_box-0.3.0.dev0` sdist + wheel, `twine check --strict` passes both, and installing the wheel into an isolated env imports and reports `0.3.0.dev0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoMja3keZx6WnKjFoKYQFe