### PR TITLE
Release 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "uv_build"
 name = "lightning-uq-box"
 # uv_build does not support dynamic versions. lightning_uq_box.__version__ reads
 # this value back at runtime via importlib.metadata.
-version = "0.3.0.dev0"
+version = "0.3.0"
 description = "Lightning-UQ-Box: A toolbox for uncertainty quantification in deep learning"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1612,7 +1612,7 @@ wheels = [
 
 [[package]]
 name = "lightning-uq-box"
-version = "0.3.0.dev0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "curvlinops-for-pytorch" },


### PR DESCRIPTION
Version bump for the 0.3.0 release: `0.3.0.dev0` → `0.3.0` in `pyproject.toml`, which since the uv migration is the only place the version is declared. `uv.lock` records the project's own version, so it is relocked in the same change.

Merge this **last**, after everything else that belongs in 0.3.0. Then `releases/0.3` gets branched here and tagged `v0.3.0`, and publishing the GitHub Release triggers the workflow from #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoMja3keZx6WnKjFoKYQFe