### PR TITLE
Bump the development version to 0.4.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "uv_build"
 name = "lightning-uq-box"
 # uv_build does not support dynamic versions. lightning_uq_box.__version__ reads
 # this value back at runtime via importlib.metadata.
-version = "0.3.0"
+version = "0.4.0.dev0"
 description = "Lightning-UQ-Box: A toolbox for uncertainty quantification in deep learning"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1612,7 +1612,7 @@ wheels = [
 
 [[package]]
 name = "lightning-uq-box"
-version = "0.3.0"
+version = "0.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "curvlinops-for-pytorch" },


### PR DESCRIPTION
Post-release housekeeping for v0.3.0, which is now on [PyPI](https://pypi.org/project/lightning-uq-box/0.3.0/). `main` moves to `0.4.0.dev0` so it no longer claims to be the released version. `uv.lock` records the project's own version, so it is relocked in the same change.

0.3.x patch fixes go on the `releases/0.3` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoMja3keZx6WnKjFoKYQFe