### PR TITLE
refactor: add task-aware Deterministic and MC Dropout APIs

### DIFF
--- a/docs/api/uq_methods.rst
+++ b/docs/api/uq_methods.rst
@@ -1,6 +1,33 @@
 lightning_uq_box.uq_methods
 ===========================
 
+Canonical method × task API (0.4)
+==================================
+
+.. currentmodule:: lightning_uq_box.uq_methods
+
+Task values and contracts
+-------------------------
+
+.. autoclass:: TaskSpec
+.. autoclass:: RegressionTask
+.. autoclass:: ClassificationTask
+.. autoclass:: SegmentationTask
+.. autoclass:: PixelRegressionTask
+.. autoclass:: OutputSchema
+.. autoclass:: TaskCapability
+.. autoclass:: MethodSpec
+
+Deterministic
+-------------
+
+.. autoclass:: Deterministic
+
+Monte Carlo Dropout
+-------------------
+
+.. autoclass:: MCDropout
+
 Single Forward Pass Methods
 ===========================
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -16,6 +16,13 @@ We welcome contributions and suggestions to this open-source project. This could
     ```
 4. Open a Pull Request (PR)
 
+## Stacked method-task migration
+
+The method/task API redesign is being delivered as a stack of focused pull
+requests. See the [method × task transition roadmap](method_task_transition.md)
+for the dependency order, compatibility policy, and required checks for each
+PR.
+
 ## Development environment
 
 We use [uv](https://docs.astral.sh/uv/) to install dependencies, both locally and in CI. It reads the extras declared in `pyproject.toml` and resolves them against the checked-in `uv.lock`, so the packages you get locally are the same versions CI runs against.

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,5 +86,6 @@ tutorial_overview
 running_experiments
 api/index
 contribute
+method_task_transition
 GitHub Repository <https://github.com/lightning-uq-box/lightning-uq-box>
 ```

--- a/docs/method_task_transition.md
+++ b/docs/method_task_transition.md
@@ -1,0 +1,102 @@
+# Method × task transition roadmap
+
+This roadmap tracks the migration from concrete method/task classes such as
+`MCDropoutRegression` to one canonical method with an explicit task value:
+
+```python
+MCDropout(
+    model=model,
+    num_mc_samples=20,
+    loss_fn=nn.CrossEntropyLoss(),
+    task=ClassificationTask(mode="multiclass"),
+)
+```
+
+It is deliberately organized as a stack of reviewable pull requests. A PR in
+this stack must only depend on the PR immediately below it (or on `main` once
+its parent has merged). Do not combine unrelated families merely to reduce the
+number of pull requests.
+
+## Compatibility policy
+
+Canonical APIs are introduced in 0.4. Existing concrete class names and their
+historical module imports remain available as deprecated adapters throughout
+0.4; adapters must retain their public constructor signatures and state-dict
+prefixes. A deprecated adapter emits `DeprecationWarning` with `stacklevel=2`.
+
+The 0.5 removal is a separate release PR and may only remove an adapter after
+the canonical replacement has shipped in a 0.4 release with its migration
+tests, configuration, and documentation.
+
+## Landed foundation PR
+
+**PR 1: task-aware foundation, Deterministic, and MC Dropout.**
+
+This PR introduces frozen, serializable task values; task/output/capability
+contracts; the private runtime and non-mutating prediction writers; and the
+canonical `Deterministic` and `MCDropout` APIs. It retains the corresponding
+legacy classes as adapters, supplies canonical configs for the four task
+families, and updates the transformed tutorials. The public API and changed
+utilities have `versionchanged` annotations.
+
+This is a vertical slice, not a declaration that the global inventory is
+complete. In particular, the full 109-config classification, distributed
+two-process writer fixture, and every checkpoint baseline remain work for the
+follow-up PRs below.
+
+## Follow-up PR stack
+
+Create each branch from the preceding PR branch while the stack is open. Rebase
+the child onto its parent after changes, then retarget it to `main` as parents
+merge. Each PR owns its code, canonical/adaptor configs, focused tests,
+`MethodSpec` capabilities, and documentation rows.
+
+| Order | Suggested PR title | Scope and required proof |
+| --- | --- | --- |
+| 2 | `refactor: add canonical SWAG` | Migrate `swag.py` with local adapters. Preserve moment collection, posterior sampling, and state restoration; test repeated test/predict calls and all declared task capabilities. |
+| 3 | `refactor: add canonical SGLD` | Migrate `sgld.py` as `SGLDMethod` so the public optimizer stays unambiguous. Preserve posterior/state semantics and prove the adapters, strict loading, and declared capabilities. |
+| 4 | `refactor: add canonical Masksembles` | Migrate `masked_ensemble.py`. Preserve mask construction, setup, freezing, optimization, and aggregation; add canonical configs and adapter/state-key tests. |
+| 5 | `refactor: add canonical BNN-VI ELBO` | Migrate `bnn_vi_elbo.py`. Keep variational-layer setup, ELBO/loss and optimizer ownership, freezing, and aggregation method-owned. |
+| 6 | `refactor: spike Deep Ensemble reconstruction` | Add serializable member descriptors and prove fresh-process strict reconstruction plus `Trainer(..., ckpt_path=...)`. Document required caller descriptors for historical artifacts. Do not add the canonical public method until this passes. |
+| 7 | `refactor: add canonical DeepEnsemble` | Build the canonical Deep Ensemble only for reconstruction-proven task pairs; retain local adapters and cover persistence, strict load, trainer restore, imports, and configs. |
+| 8 | `refactor: spike DKL and DUE checkpoint topology` | Save/rebuild GP topology before strict loading for regression and classification DKL/DUE. Derive historical dimensions only from saved hparams/inducing-point state and retain method-owned GP lifecycle. |
+| 9 | `refactor: add canonical DKL and DUE` | Expose only topology-proven capabilities, bind local adapters, and preserve explicit GP output conversion contracts. No lazy runtime and no non-strict load fallback. |
+| 10 | `refactor: migrate Gaussian, evidential, and quantile methods` | Migrate MVE, DER, and Quantile Regression. Keep distributions and quantile conversion local; fixed-output tests must prove multi-target handling and scalar (`lower_quant`/`upper_quant`) versus pixel (`lower`/`upper`) result keys. |
+| 11 | `refactor: migrate mixture and density methods` | Migrate MDN and DensityLayerModel. Keep mixture/density conversions method-specific; do not rely on a generic two-channel interpretation. |
+| 12 | `refactor: migrate model rewriters` | Migrate VBLL, SNGP, BNNVI, and BNNLVVI. Assert construction order: rewrite/attachment, runtime registration, then trainer/device/optimizer/checkpoint work. Preserve module structure, freezing, loss, and optimizer ownership. |
+| 13 | `refactor: migrate standalone wrappers` | Migrate ZigZag, CARD, and Laplace. Alias the third-party Laplace dependency internally and precisely document post-fit and caller-dependency checkpoint limits. |
+| 14 | `docs: close method-task inventory` | Classify all remaining exports: conformal methods, RAPS, temperature scaling, inference-time augmentation, ProbUNet/VAE, and image-to-image helpers. Each is canonical, retained legacy, a post-hoc canonical-output consumer, or explicitly out of scope; do not force an invalid task API. |
+| 15 | `docs: publish method-task compatibility matrix` | Make documentation and release notes complete: task serialization, capabilities, binary/multilabel encoding, output keys, persistence, checkpoint boundaries, and old-to-new paths. Check documentation rows against `MethodSpec`, and instantiate canonical examples. |
+| 16 | `release: remove 0.4 method-task adapters` | The 0.5-only removal PR. Delete only adapters and legacy configs whose canonical replacement has shipped and been release-noted. |
+
+## Non-negotiable checks for every migration PR
+
+- Declare each public task/mode with `TaskCapability` and `OutputSchema` in
+  `MethodSpec`; do not advertise an untested pair.
+- Add a minimal smoke factory, fixed-output contract test, canonical config,
+  API documentation row, and legacy import/signature/warning test for every
+  capability.
+- Preserve method-owned behavior: head/loss conversion, sampling, model
+  rewrites, freezing, optimizer ownership, lifecycle state, and public result
+  keys must not be generalized into task shape heuristics.
+- Test batch size one, explicit binary encoding (one-logit BCE/sigmoid or
+  two-logit CE/softmax), multilabel targets, and applicable writer behavior.
+- For constructor or topology changes, test strict state-dict loading,
+  `Trainer` restore with `ckpt_path`, and direct `load_from_checkpoint` when
+  all dependencies are serializable or explicitly supplied by the caller.
+- Verify writers copy outputs, preserve single-rank `preds.csv` and dense HDF5
+  behavior, and add/retain rank plus dataset-index shard/manifest coverage for
+  distributed persistence.
+- Run focused tests, the affected existing task tests, both configuration
+  dialects when applicable, `uv run ruff check`, `uv run ty check`, and the
+  relevant documentation build. At each layer boundary, also run MethodSpec
+  smokes and the full configuration suite.
+
+## Final completion criteria
+
+The transition is complete only when every declared capability is documented
+and tested; 0.4 adapters retain imports, signatures, and applicable strict
+loads; task/runtime objects do not become checkpoint hyperparameters or
+persistent state; method-specific behavior remains contract-tested; and
+single- and multi-process prediction persistence is non-mutating and
+collision-free.

--- a/docs/tutorials/classification/deterministic.ipynb
+++ b/docs/tutorials/classification/deterministic.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "from lightning_uq_box.datamodules import TwoMoonsDataModule\n",
     "from lightning_uq_box.models import MLP\n",
-    "from lightning_uq_box.uq_methods import DeterministicClassification\n",
+    "from lightning_uq_box.uq_methods import ClassificationTask, Deterministic\n",
     "from lightning_uq_box.viz_utils import (\n",
     "    plot_predictions_classification,\n",
     "    plot_training_metrics,\n",
@@ -150,8 +150,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mc_dropout_module = DeterministicClassification(\n",
-    "    model=network, optimizer=partial(Adam, lr=1e-2), loss_fn=nn.CrossEntropyLoss()\n",
+    "deterministic_module = Deterministic(\n",
+    "    model=network,\n",
+    "    optimizer=partial(Adam, lr=1e-2),\n",
+    "    loss_fn=nn.CrossEntropyLoss(),\n",
+    "    task=ClassificationTask(mode=\"multiclass\"),\n",
     ")"
    ]
   },
@@ -189,7 +192,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer.fit(mc_dropout_module, dm)"
+    "trainer.fit(deterministic_module, dm)"
    ]
   },
   {
@@ -228,7 +231,7 @@
    "outputs": [],
    "source": [
     "# save predictions\n",
-    "trainer.test(mc_dropout_module, dm.test_dataloader())"
+    "trainer.test(deterministic_module, dm.test_dataloader())"
    ]
   },
   {
@@ -238,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "preds = mc_dropout_module.predict_step(test_grid_points)"
+    "preds = deterministic_module.predict_step(test_grid_points)"
    ]
   },
   {

--- a/docs/tutorials/classification/mc_dropout.ipynb
+++ b/docs/tutorials/classification/mc_dropout.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "from lightning_uq_box.datamodules import TwoMoonsDataModule\n",
     "from lightning_uq_box.models import MLP\n",
-    "from lightning_uq_box.uq_methods import MCDropoutClassification\n",
+    "from lightning_uq_box.uq_methods import ClassificationTask, MCDropout\n",
     "from lightning_uq_box.viz_utils import (\n",
     "    plot_predictions_classification,\n",
     "    plot_training_metrics,\n",
@@ -148,11 +148,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mc_dropout_module = MCDropoutClassification(\n",
+    "mc_dropout_module = MCDropout(\n",
     "    model=network,\n",
     "    optimizer=partial(Adam, lr=1e-2),\n",
     "    loss_fn=nn.CrossEntropyLoss(),\n",
     "    num_mc_samples=25,\n",
+    "    task=ClassificationTask(mode=\"multiclass\"),\n",
     ")"
    ]
   },

--- a/docs/tutorials/regression/mc_dropout.ipynb
+++ b/docs/tutorials/regression/mc_dropout.ipynb
@@ -81,7 +81,7 @@
     "\n",
     "from lightning_uq_box.datamodules import ToyHeteroscedasticDatamodule\n",
     "from lightning_uq_box.models import MLP\n",
-    "from lightning_uq_box.uq_methods import NLL, MCDropoutRegression\n",
+    "from lightning_uq_box.uq_methods import NLL, MCDropout, RegressionTask\n",
     "from lightning_uq_box.viz_utils import (\n",
     "    plot_calibration_uq_toolbox,\n",
     "    plot_predictions_regression,\n",
@@ -203,12 +203,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mc_dropout_module = MCDropoutRegression(\n",
+    "mc_dropout_module = MCDropout(\n",
     "    model=network,\n",
     "    optimizer=partial(Adam, lr=1e-2),\n",
     "    loss_fn=NLL(),\n",
     "    num_mc_samples=25,\n",
     "    burnin_epochs=50,\n",
+    "    prediction_kind=\"gaussian\",\n",
+    "    task=RegressionTask(),\n",
     ")"
    ]
   },

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -57,6 +57,43 @@ The following aims to explain the design choices behind the implementations foun
   implemented in the subclasses but can be util functions that could still be utilized by users for their own usage
 - try to integrate existing implementations into this framework to not reinvent the wheel
 
+## Canonical method × task API (0.4)
+
+Newly migrated methods use one method class and an explicit immutable task value.
+The first canonical methods are `Deterministic` and `MCDropout`:
+
+```python
+from torch import nn
+
+from lightning_uq_box.uq_methods import MCDropout, SegmentationTask
+
+method = MCDropout(
+    model,
+    num_mc_samples=20,
+    loss_fn=nn.CrossEntropyLoss(),
+    task=SegmentationTask(mode="multiclass"),
+)
+```
+
+Supported values are `RegressionTask`, `ClassificationTask`,
+`SegmentationTask`, and `PixelRegressionTask`. Classification has explicit
+`binary`, `multiclass`, and `multilabel` modes. Binary tasks also declare
+`binary_encoding="one_logit"` (BCE/sigmoid) or `"two_logit"`
+(CE/softmax); the library never infers this choice from tensor shape.
+
+Canonical methods save a versioned allow-listed mapping under `task` in their
+checkpoint hyperparameters, rather than serializing a task object. Hydra's
+`_target_` syntax and LightningCLI's `class_path`/`init_args` syntax are both
+accepted. A `MethodSpec` declares each exposed task/mode capability and its
+output schema, so unsupported pairs fail during construction.
+
+The historical concrete task classes remain import-compatible during 0.4 while
+their canonical replacement is introduced. They are the compatibility route;
+new code should use the canonical method/task form. Prediction writers copy the
+step output before persistence. Single-process tabular outputs remain
+`preds.csv` and dense outputs remain HDF5 under `preds/`; distributed writers
+create rank shards plus a root manifest to avoid collisions.
+
 ## Pytorch and Lightning
 - use [PyTorch](https://pytorch.org/docs/stable/index.html), because:
   - wide adaptation in research community

--- a/lightning_uq_box/uq_methods/__init__.py
+++ b/lightning_uq_box/uq_methods/__init__.py
@@ -5,12 +5,14 @@
 
 from .base import (
     BaseModule,
+    Deterministic,
     DeterministicClassification,
     DeterministicModel,
     DeterministicPixelRegression,
     DeterministicRegression,
     DeterministicSegmentation,
     PosthocBase,
+    TaskMethodBase,
 )
 from .bnn_lv_vi import (
     BNN_LV_VI_Base,
@@ -27,6 +29,7 @@ from .bnn_vi_elbo import (
 )
 from .cards import CARDBase, CARDClassification, CARDRegression, NoiseScheduler
 from .conformal_qr import ConformalQR
+from .contracts import MethodSpec, OutputField, OutputSchema, TaskCapability
 from .deep_ensemble import (
     DeepEnsemble,
     DeepEnsembleClassification,
@@ -58,6 +61,7 @@ from .masked_ensemble import (
     MasksemblesRegression,
 )
 from .mc_dropout import (
+    MCDropout,
     MCDropoutBase,
     MCDropoutClassification,
     MCDropoutPxRegression,
@@ -65,6 +69,12 @@ from .mc_dropout import (
     MCDropoutSegmentation,
 )
 from .mean_variance_estimation import MVEBase, MVEPxRegression, MVERegression
+from .method_specs import (
+    DETERMINISTIC_SPEC,
+    MCDROPOUT_SPEC,
+    get_method_spec,
+    iter_method_specs,
+)
 from .mixture_density import MDNRegression
 from .prob_unet import ProbUNet
 from .quantile_regression import (
@@ -89,6 +99,15 @@ from .swag import (
     SWAGRegression,
     SWAGSegmentation,
 )
+from .tasks import (
+    ClassificationTask,
+    PixelRegressionTask,
+    RegressionTask,
+    SegmentationTask,
+    TaskSpec,
+    normalize_task,
+    task_from_mapping,
+)
 from .temp_scaling import TempScaling
 from .vae import VAE, ConditionalVAE
 from .vbll import VBLLClassification, VBLLRegression
@@ -98,7 +117,25 @@ __all__ = (
     # Base Module
     "BaseModule",
     "PosthocBase",
+    "TaskMethodBase",
+    # canonical task values and contracts
+    "TaskSpec",
+    "RegressionTask",
+    "ClassificationTask",
+    "SegmentationTask",
+    "PixelRegressionTask",
+    "normalize_task",
+    "task_from_mapping",
+    "OutputField",
+    "OutputSchema",
+    "TaskCapability",
+    "MethodSpec",
+    "DETERMINISTIC_SPEC",
+    "MCDROPOUT_SPEC",
+    "get_method_spec",
+    "iter_method_specs",
     # base model
+    "Deterministic",
     "DeterministicModel",
     "DeterministicClassification",
     "DeterministicRegression",
@@ -112,6 +149,7 @@ __all__ = (
     # conformalized Quantile Regression
     "ConformalQR",
     # MC-Dropout
+    "MCDropout",
     "MCDropoutBase",
     "MCDropoutRegression",
     "MCDropoutClassification",

--- a/lightning_uq_box/uq_methods/_deprecated.py
+++ b/lightning_uq_box/uq_methods/_deprecated.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Small shared helpers for 0.4 compatibility adapters.
+
+Deprecated classes intentionally bind their own exports in their historical
+modules.  Keeping the warning helper here avoids a replacement class factory,
+which would obscure signatures and can change checkpoint state-dict prefixes.
+"""
+
+from warnings import warn
+
+
+def warn_legacy_adapter(old_name: str, replacement: str) -> None:
+    """Warn callers that a concrete task class is a 0.4 compatibility adapter."""
+    warn(
+        f"{old_name} is deprecated and will be removed in 0.5; use {replacement} "
+        "with an explicit task value instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+__all__ = ["warn_legacy_adapter"]

--- a/lightning_uq_box/uq_methods/base.py
+++ b/lightning_uq_box/uq_methods/base.py
@@ -4,6 +4,7 @@
 """Base Model for UQ methods."""
 
 import os
+from collections.abc import Mapping
 from typing import Any, ClassVar
 
 import torch
@@ -14,6 +15,17 @@ from omegaconf import OmegaConf
 from torch import Tensor, nn
 from torchmetrics import MetricCollection
 
+from ._deprecated import warn_legacy_adapter
+from .method_specs import DETERMINISTIC_SPEC
+from .task_runtime import TaskRuntime
+from .tasks import (
+    ClassificationTask,
+    PixelRegressionTask,
+    RegressionTask,
+    SegmentationTask,
+    TaskSpec,
+    normalize_task,
+)
 from .utils import (
     _get_num_inputs,
     _get_num_outputs,
@@ -30,6 +42,11 @@ from .utils import (
     save_image_predictions,
     save_regression_predictions,
 )
+
+# ``DeterministicModel`` and its subclasses below are the 0.4 compatibility
+# implementation.  Canonical task-aware methods intentionally live beside them
+# until every historical class has an adapter; changing this base in place would
+# alter old constructor signatures and state-dict prefixes.
 
 
 class BaseModule(LightningModule):
@@ -306,9 +323,31 @@ class DeterministicModel(BaseModule):
 
 
 class DeterministicRegression(DeterministicModel):
-    """Deterministic Base Trainer for regression as LightningModule."""
+    """Deprecated deterministic regression compatibility adapter.
+
+    .. versionchanged:: 0.4.0
+
+       Use :class:`Deterministic` with :class:`RegressionTask` for new code.
+       This adapter keeps its historical constructor and state-dict prefixes
+       through 0.4 and emits :class:`DeprecationWarning` when constructed.
+    """
 
     pred_file_name = "preds.csv"
+
+    def __init__(
+        self,
+        model: nn.Module,
+        loss_fn: nn.Module,
+        freeze_backbone: bool = False,
+        optimizer: OptimizerCallable = torch.optim.Adam,
+        lr_scheduler: LRSchedulerCallable | None = None,
+    ) -> None:
+        """Initialize the deprecated regression adapter with its old signature."""
+        if type(self) is DeterministicRegression:
+            warn_legacy_adapter(
+                "DeterministicRegression", "Deterministic(..., task=RegressionTask())"
+            )
+        super().__init__(model, loss_fn, freeze_backbone, optimizer, lr_scheduler)
 
     def setup_task(self) -> None:
         """Set up task specific attributes."""
@@ -333,7 +372,14 @@ class DeterministicRegression(DeterministicModel):
 
 
 class DeterministicClassification(DeterministicModel):
-    """Deterministic Base Trainer for classification as LightningModule."""
+    """Deprecated deterministic classification compatibility adapter.
+
+    .. versionchanged:: 0.4.0
+
+       Use :class:`Deterministic` with :class:`ClassificationTask` for new
+       code. This adapter retains the historical string ``task`` argument and
+       state-dict prefixes through 0.4.
+    """
 
     pred_file_name = "preds.csv"
 
@@ -359,6 +405,11 @@ class DeterministicClassification(DeterministicModel):
             optimizer: optimizer used for training
             lr_scheduler: learning rate scheduler
         """
+        if type(self) is DeterministicClassification:
+            warn_legacy_adapter(
+                "DeterministicClassification",
+                "Deterministic(..., task=ClassificationTask(...))",
+            )
         self.num_classes = _get_num_outputs(model)
         assert task in self.valid_tasks, f"Task must be one of {self.valid_tasks}"
         self.task = task
@@ -423,7 +474,14 @@ class DeterministicClassification(DeterministicModel):
 
 
 class DeterministicSegmentation(DeterministicClassification):
-    """Deterministic Base Trainer for segmentation as LightningModule."""
+    """Deprecated deterministic segmentation compatibility adapter.
+
+    .. versionchanged:: 0.4.0
+
+       Use :class:`Deterministic` with :class:`SegmentationTask` for new code.
+       The adapter preserves the old constructor, dense prediction path, and
+       state-dict prefixes through 0.4.
+    """
 
     pred_dir_name = "preds"
 
@@ -453,6 +511,11 @@ class DeterministicSegmentation(DeterministicClassification):
             lr_scheduler: learning rate scheduler
             save_preds: whether to save predictions
         """
+        if type(self) is DeterministicSegmentation:
+            warn_legacy_adapter(
+                "DeterministicSegmentation",
+                "Deterministic(..., task=SegmentationTask(...))",
+            )
         self.freeze_backbone = freeze_backbone
         self.freeze_decoder = freeze_decoder
         super().__init__(model, loss_fn, task, freeze_backbone, optimizer, lr_scheduler)
@@ -518,7 +581,14 @@ class DeterministicSegmentation(DeterministicClassification):
 
 
 class DeterministicPixelRegression(DeterministicRegression):
-    """Deterministic Base Trainer for pixel regression as LightningModule."""
+    """Deprecated deterministic pixel-regression compatibility adapter.
+
+    .. versionchanged:: 0.4.0
+
+       Use :class:`Deterministic` with :class:`PixelRegressionTask` for new
+       code. The adapter preserves dense output persistence and its historical
+       constructor/state-dict surface through 0.4.
+    """
 
     pred_dir_name = "preds"
 
@@ -543,6 +613,11 @@ class DeterministicPixelRegression(DeterministicRegression):
             lr_scheduler: learning rate scheduler
             save_preds: whether to save predictions
         """
+        if type(self) is DeterministicPixelRegression:
+            warn_legacy_adapter(
+                "DeterministicPixelRegression",
+                "Deterministic(..., task=PixelRegressionTask())",
+            )
         self.freeze_decoder = freeze_decoder
         super().__init__(model, loss_fn, freeze_backbone, optimizer, lr_scheduler)
         self.save_preds = save_preds
@@ -580,6 +655,331 @@ class DeterministicPixelRegression(DeterministicRegression):
         """
         if self.save_preds:
             save_image_predictions(outputs, batch_idx, self.pred_dir)
+
+
+class TaskMethodBase(BaseModule):
+    """Small base class for canonical methods with an explicit task value.
+
+    This class deliberately has no shape-based task inference.  A concrete
+    canonical method owns its model rewrites and then calls
+    :meth:`initialize_task_runtime`, which validates the declared capability
+    and eagerly registers the private runtime child.
+
+    .. versionadded:: 0.4.0
+    """
+
+    method_spec = None
+
+    def __init__(self, task: TaskSpec | Mapping[str, Any] | None = None) -> None:
+        """Initialize a canonical task-aware module.
+
+        Args:
+            task: immutable task value, a supported config mapping, or ``None``.
+                Concrete methods decide what ``None`` means; no task object is
+                used as a Python default.
+        """
+        super().__init__()
+        self.task = task
+        self.task_runtime: TaskRuntime
+        self._output_schema: Any
+
+    def initialize_task_runtime(
+        self, task: TaskSpec | Mapping[str, Any] | None, *, default_task: TaskSpec
+    ) -> None:
+        """Validate a task and register its eager, non-persistent runtime.
+
+        Args:
+            task: public constructor task argument.
+            default_task: freshly created fallback selected by the method.
+
+        Raises:
+            ValueError: if this canonical method has no declared capability for
+                the supplied task.
+        """
+        normalized = normalize_task(task, default=default_task)
+        assert normalized is not None
+        if self.method_spec is None:
+            raise TypeError("Canonical methods must declare a MethodSpec.")
+        capability = self.method_spec.capability_for(normalized)
+        self.task = normalized
+        self._output_schema = capability.schema
+        self.task_runtime = TaskRuntime(
+            normalized, capability.schema, _get_num_outputs(self.model)
+        )
+
+    @property
+    def output_schema(self) -> Any:
+        """Return the selected immutable output schema."""
+        return self._output_schema
+
+    def supports_task(self, task: TaskSpec | Mapping[str, Any]) -> bool:
+        """Return whether a task mapping/value is a declared capability."""
+        normalized = normalize_task(task)
+        assert normalized is not None
+        try:
+            self.method_spec.capability_for(normalized)
+        except ValueError:
+            return False
+        return True
+
+    def save_task_hyperparameters(self, values: Mapping[str, Any]) -> None:
+        """Save only a serializable mapping for the task in hyperparameters."""
+        if not isinstance(self.task, TaskSpec):
+            raise TypeError("Task runtime must be initialized before saving hparams.")
+        hparams = dict(values)
+        hparams["task"] = self.task.to_mapping()
+        self.save_hyperparameters(hparams)
+
+    @property
+    def train_metrics(self) -> MetricCollection:
+        """Expose run-only training metrics for Lightning and callers."""
+        return self.task_runtime.train_metrics
+
+    @property
+    def val_metrics(self) -> MetricCollection:
+        """Expose run-only validation metrics for Lightning and callers."""
+        return self.task_runtime.val_metrics
+
+    @property
+    def test_metrics(self) -> MetricCollection:
+        """Expose run-only test metrics for Lightning and callers."""
+        return self.task_runtime.test_metrics
+
+
+class Deterministic(TaskMethodBase):
+    """Canonical deterministic method parameterized by a task value.
+
+    The legacy ``Deterministic*`` classes remain available during 0.4.  New
+    callers should use this class with a :mod:`uq_methods.tasks` value, for
+    example ``Deterministic(model, nn.MSELoss(), task=RegressionTask())``.
+
+    .. versionchanged:: 0.4.0
+
+       Deterministic execution is now selected by an explicit immutable task
+       value. Task normalization, metrics, test results, and persistence are
+       delegated to a registered runtime; loss, model execution, freezing, and
+       output conversion remain owned by this method.
+    """
+
+    method_spec = DETERMINISTIC_SPEC
+    pred_file_name = "preds.csv"
+    pred_dir_name = "preds"
+
+    def __init__(
+        self,
+        model: nn.Module,
+        loss_fn: nn.Module,
+        *,
+        task: TaskSpec | Mapping[str, Any] | None = None,
+        freeze_backbone: bool = False,
+        freeze_decoder: bool = False,
+        optimizer: OptimizerCallable = torch.optim.Adam,
+        lr_scheduler: LRSchedulerCallable | None = None,
+        save_preds: bool = False,
+    ) -> None:
+        """Initialize the canonical deterministic method.
+
+        Args:
+            model: a model whose output matches the declared task contract.
+            loss_fn: method-owned optimization loss.
+            task: task semantics as a value or config mapping.  ``None`` uses
+                ``RegressionTask()`` for a backwards-friendly canonical default.
+            freeze_backbone: freeze the model backbone before training.
+            freeze_decoder: freeze a segmentation decoder when present.
+            optimizer: optimizer factory.
+            lr_scheduler: optional learning-rate scheduler factory.
+            save_preds: persist dense test predictions for segmentation/pixel
+                regression tasks.
+        """
+        super().__init__(task)
+        self.model = model
+        self.loss_fn = loss_fn
+        self.optimizer = optimizer
+        self.lr_scheduler = lr_scheduler
+        self.freeze_backbone = freeze_backbone
+        self.freeze_decoder = freeze_decoder
+        self.save_preds = save_preds
+
+        # Method-owned model preparation is complete before this creates the
+        # registered runtime and well before a Trainer, device, or checkpoint.
+        self.initialize_task_runtime(task, default_task=RegressionTask())
+        self.freeze_model()
+        self.save_task_hyperparameters(
+            {
+                "freeze_backbone": freeze_backbone,
+                "freeze_decoder": freeze_decoder,
+                "save_preds": save_preds,
+            }
+        )
+        self.pred_dir: str | None = None
+
+    def freeze_model(self) -> None:
+        """Apply the task-appropriate legacy-compatible freezing operation."""
+        if isinstance(self.task, SegmentationTask | PixelRegressionTask):
+            freeze_segmentation_model(
+                self.model, self.freeze_backbone, self.freeze_decoder
+            )
+        elif self.freeze_backbone:
+            freeze_model_backbone(self.model)
+
+    def forward(self, X: Tensor) -> Any:
+        """Run the owning model on an input tensor."""
+        return self.model(X)
+
+    def _validate_raw_output(self, out: Tensor) -> None:
+        """Validate explicit binary encoding without inferring it from shape."""
+        if not isinstance(self.task, ClassificationTask) or self.task.mode != "binary":
+            return
+        expected_channels = 1 if self.task.binary_encoding == "one_logit" else 2
+        if out.ndim < 2 or out.shape[1] != expected_channels:
+            raise ValueError(
+                f"{self.task.binary_encoding} binary task requires {expected_channels} "
+                f"logit channel(s) at axis 1, got shape {tuple(out.shape)}."
+            )
+
+    def metric_prediction(self, raw_output: Tensor, stage: str) -> Tensor:
+        """Return the method-declared metric input for a raw model output.
+
+        ``stage`` is part of the public conversion hook so sampling and
+        distributional methods can keep their own lifecycle semantics.
+        """
+        del stage
+        self._validate_raw_output(raw_output)
+        if (
+            isinstance(self.task, ClassificationTask)
+            and self.task.mode == "binary"
+            and self.task.binary_encoding == "one_logit"
+        ):
+            return raw_output.select(1, 0)
+        return raw_output
+
+    def prediction_payload(self, raw_output: Tensor) -> dict[str, Tensor]:
+        """Convert one deterministic raw output to its declared public payload."""
+        self._validate_raw_output(raw_output)
+        if not isinstance(self.task, ClassificationTask):
+            return {"pred": raw_output}
+
+        if self.task.mode == "multilabel":
+            probabilities = torch.sigmoid(raw_output)
+            entropy = -(
+                probabilities.clamp_min(1e-7).log() * probabilities
+                + (1 - probabilities).clamp_min(1e-7).log() * (1 - probabilities)
+            ).sum(dim=1)
+        elif self.task.mode == "binary" and self.task.binary_encoding == "one_logit":
+            probabilities = torch.sigmoid(raw_output)
+            clipped = probabilities.clamp(1e-7, 1 - 1e-7)
+            entropy = -(
+                clipped * clipped.log() + (1 - clipped) * (1 - clipped).log()
+            ).select(1, 0)
+        else:
+            probabilities = torch.softmax(raw_output, dim=1).clamp_min(1e-7)
+            entropy = -(probabilities * probabilities.log()).sum(dim=1)
+        return {"pred": probabilities, "pred_uct": entropy, "logits": raw_output}
+
+    def _step_loss_and_metrics(self, batch: dict[str, Tensor], stage: str) -> Tensor:
+        """Run a train/validation batch and update the runtime metrics."""
+        raw_output = self.forward(batch[self.input_key])
+        if not isinstance(raw_output, Tensor):
+            raise TypeError("Canonical Deterministic requires a Tensor model output.")
+        loss = self.loss_fn(
+            raw_output,
+            self.task_runtime.target_for_loss(batch[self.target_key], raw_output),
+        )
+        self.task_runtime.update_metrics(
+            stage, self.metric_prediction(raw_output, stage), batch[self.target_key]
+        )
+        return loss
+
+    def training_step(
+        self, batch: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> Tensor:
+        """Compute the canonical deterministic training loss."""
+        del batch_idx, dataloader_idx
+        loss = self._step_loss_and_metrics(batch, "train")
+        self.log("train_loss", loss, batch_size=batch[self.input_key].shape[0])
+        return loss
+
+    def validation_step(
+        self, batch: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> Tensor:
+        """Compute the canonical deterministic validation loss."""
+        del batch_idx, dataloader_idx
+        loss = self._step_loss_and_metrics(batch, "validate")
+        self.log("val_loss", loss, batch_size=batch[self.input_key].shape[0])
+        return loss
+
+    def on_train_epoch_end(self) -> None:
+        """Log and reset runtime-owned training metrics."""
+        self.log_dict(self.task_runtime.compute_and_reset("train"))
+
+    def on_validation_epoch_end(self) -> None:
+        """Log and reset runtime-owned validation metrics."""
+        self.log_dict(self.task_runtime.compute_and_reset("validate"))
+
+    def predict_step(
+        self, X: Tensor, batch_idx: int = 0, dataloader_idx: int = 0
+    ) -> dict[str, Tensor]:
+        """Return a contract-checked canonical prediction payload."""
+        del batch_idx, dataloader_idx
+        with torch.no_grad():
+            raw_output = self.forward(X)
+        if not isinstance(raw_output, Tensor):
+            raise TypeError("Canonical Deterministic requires a Tensor model output.")
+        payload = self.prediction_payload(raw_output)
+        self.output_schema.validate_payload(payload)
+        return payload
+
+    def test_step(
+        self, batch: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> dict[str, Any]:
+        """Create a copied test result while updating runtime metrics."""
+        del batch_idx, dataloader_idx
+        with torch.no_grad():
+            raw_output = self.forward(batch[self.input_key])
+        if not isinstance(raw_output, Tensor):
+            raise TypeError("Canonical Deterministic requires a Tensor model output.")
+        payload = self.prediction_payload(raw_output)
+        self.output_schema.validate_payload(payload)
+        self.task_runtime.update_metrics(
+            "test", self.metric_prediction(raw_output, "test"), batch[self.target_key]
+        )
+        return self.task_runtime.test_result(
+            payload, batch, input_key=self.input_key, target_key=self.target_key
+        )
+
+    def on_test_epoch_end(self) -> None:
+        """Log and reset runtime-owned test metrics."""
+        self.log_dict(self.task_runtime.compute_and_reset("test"))
+
+    def on_test_start(self) -> None:
+        """Delegate dense-prediction directory setup to the task runtime."""
+        self.pred_dir = self.task_runtime.on_test_start(
+            self.trainer.default_root_dir, self.save_preds
+        )
+
+    def on_test_batch_end(
+        self, outputs: STEP_OUTPUT, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Delegate non-mutating canonical prediction persistence."""
+        del batch, dataloader_idx
+        self.task_runtime.write_test_result(
+            outputs,
+            root_dir=self.trainer.default_root_dir,
+            batch_idx=batch_idx,
+            save_predictions=self.save_preds,
+            prediction_dir=self.pred_dir,
+        )
+
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        """Initialize the owning optimizer and optional scheduler."""
+        optimizer = self.optimizer(self.parameters())
+        if self.lr_scheduler is None:
+            return {"optimizer": optimizer}
+        scheduler = self.lr_scheduler(optimizer)
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {"scheduler": scheduler, "monitor": "val_loss"},
+        }
 
 
 class PosthocBase(BaseModule):

--- a/lightning_uq_box/uq_methods/contracts.py
+++ b/lightning_uq_box/uq_methods/contracts.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Explicit contracts for the canonical method × task API.
+
+The old concrete classes encoded these contracts implicitly in inheritance and
+tensor slicing.  The canonical API makes them data so capabilities can be
+validated before a trainer or a checkpoint is involved.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from torch import Tensor
+
+from .tasks import ClassificationTask, TaskSpec
+
+if TYPE_CHECKING:
+    from torch import nn
+
+
+Stage = Literal["train", "validate", "test", "predict"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class OutputField:
+    """A public prediction field.
+
+    ``axes`` describes semantic axes instead of freezing dimensions.  For
+    example ``("batch", "class", "height", "width")`` remains valid for
+    any image size and any number of classes.
+    """
+
+    name: str
+    axes: tuple[str, ...]
+    dtype: str = "floating"
+    device: str = "model"
+    required: bool = True
+    description: str = ""
+
+
+@dataclass(frozen=True, kw_only=True)
+class OutputSchema:
+    """Immutable output and metric contract for a method/task pair."""
+
+    task_type: type[TaskSpec]
+    modes: frozenset[str] = frozenset()
+    raw_axes: tuple[str, ...]
+    metric_input: str
+    fields: tuple[OutputField, ...]
+    binary_encoding: str | None = None
+    uncertainty_fields: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        """Validate immutable schema invariants at construction time."""
+        names = [field.name for field in self.fields]
+        if len(names) != len(set(names)):
+            raise ValueError("OutputSchema fields must have unique names.")
+        if "pred" not in names:
+            raise ValueError("Every OutputSchema must expose a 'pred' field.")
+        if not self.metric_input:
+            raise ValueError("OutputSchema.metric_input must not be empty.")
+        if self.modes and not issubclass(self.task_type, ClassificationTask):
+            raise ValueError("Only classification-like tasks may declare modes.")
+        if self.binary_encoding and "binary" not in self.modes:
+            raise ValueError("binary_encoding requires a binary schema mode.")
+        if not self.uncertainty_fields.issubset(set(names)):
+            raise ValueError("uncertainty_fields must be public schema fields.")
+
+    @property
+    def public_keys(self) -> frozenset[str]:
+        """Return all public output keys, including optional keys."""
+        return frozenset(field.name for field in self.fields)
+
+    def accepts(self, task: TaskSpec) -> bool:
+        """Whether the schema is applicable to ``task``."""
+        # Capabilities are exact method × task declarations.  Segmentation is
+        # a subclass of ClassificationTask for shared mode fields, but it must
+        # never accidentally match a vector-classification capability.
+        if type(task) is not self.task_type:
+            return False
+        mode = getattr(task, "mode", None)
+        if self.modes and mode not in self.modes:
+            return False
+        if self.binary_encoding and mode == "binary":
+            return getattr(task, "binary_encoding", None) == self.binary_encoding
+        return True
+
+    def validate_payload(self, payload: dict[str, Tensor]) -> None:
+        """Validate public keys and the rank implied by declared axes.
+
+        Dynamic axis dimensions and dtype families are checked by the owning
+        method's tests.  This check catches the expensive-to-debug contract
+        errors: a missing key, an accidental private key, or an axis squeeze
+        when the batch has one sample.
+        """
+        known = {field.name: field for field in self.fields}
+        unknown = set(payload) - set(known)
+        if unknown:
+            raise ValueError(
+                f"Prediction payload has undeclared keys: {sorted(unknown)}"
+            )
+        missing = [
+            field.name
+            for field in self.fields
+            if field.required and field.name not in payload
+        ]
+        if missing:
+            raise ValueError(f"Prediction payload is missing required keys: {missing}")
+        for name, value in payload.items():
+            if not isinstance(value, Tensor):
+                raise TypeError(f"Prediction payload '{name}' must be a Tensor.")
+            expected_rank = len(known[name].axes)
+            if value.ndim != expected_rank:
+                raise ValueError(
+                    f"Prediction payload '{name}' has rank {value.ndim}; "
+                    f"the schema requires {expected_rank} axes {known[name].axes}."
+                )
+
+
+@dataclass(frozen=True, kw_only=True)
+class TaskCapability:
+    """A tested task/mode and output schema supported by one method."""
+
+    task_type: type[TaskSpec]
+    modes: frozenset[str] = frozenset()
+    schema: OutputSchema
+    stages: frozenset[Stage] = frozenset({"train", "validate", "test", "predict"})
+    smoke_factory_id: str
+    test_id: str
+    config_path: str
+    writer: str
+    checkpoint_fixture_id: str
+    lifecycle_notes: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate that the capability exactly matches its schema."""
+        if self.schema.task_type is not self.task_type:
+            raise ValueError("Capability schema and task_type must agree.")
+        if self.modes != self.schema.modes:
+            raise ValueError("Capability modes and schema modes must agree.")
+        if not self.stages:
+            raise ValueError("A capability must support at least one stage.")
+        if not self.smoke_factory_id:
+            raise ValueError("A capability must name its smoke factory.")
+        if not self.test_id or not self.config_path:
+            raise ValueError("A capability must name its test and config coverage.")
+        if self.writer not in {"csv", "hdf5", "none"}:
+            raise ValueError("Capability writer must be 'csv', 'hdf5', or 'none'.")
+        if not self.checkpoint_fixture_id:
+            raise ValueError("A capability must name its checkpoint fixture.")
+
+    def accepts(self, task: TaskSpec, stage: Stage | None = None) -> bool:
+        """Return whether this capability supports ``task`` at ``stage``."""
+        return self.schema.accepts(task) and (stage is None or stage in self.stages)
+
+    @property
+    def identifier(self) -> tuple[type[TaskSpec], tuple[str, ...], str | None]:
+        """Return a stable key used to reject duplicate capabilities."""
+        return (self.task_type, tuple(sorted(self.modes)), self.schema.binary_encoding)
+
+
+SmokeFactory = Callable[[], tuple["nn.Module", dict[str, Tensor]]]
+
+
+@dataclass(frozen=True, kw_only=True)
+class MethodSpec:
+    """Checked-in source of truth for a canonical method's capabilities."""
+
+    name: str
+    class_path: str
+    capabilities: tuple[TaskCapability, ...]
+    smoke_factories: dict[str, SmokeFactory] = field(default_factory=dict)
+    config_paths: tuple[str, ...] = ()
+    documentation_path: str | None = None
+    lifecycle_notes: str = ""
+    checkpoint_fixture_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate inventory completeness and capability uniqueness."""
+        if not self.name or not self.class_path:
+            raise ValueError("MethodSpec needs a name and class_path.")
+        if not self.capabilities:
+            raise ValueError("MethodSpec must declare at least one capability.")
+        identifiers = [capability.identifier for capability in self.capabilities]
+        if len(identifiers) != len(set(identifiers)):
+            raise ValueError(f"MethodSpec {self.name} has duplicate capabilities.")
+        missing_factories = {
+            capability.smoke_factory_id for capability in self.capabilities
+        } - set(self.smoke_factories)
+        if missing_factories:
+            raise ValueError(
+                f"MethodSpec {self.name} is missing smoke factories: "
+                f"{sorted(missing_factories)}"
+            )
+
+    def capability_for(
+        self, task: TaskSpec, stage: Stage | None = None
+    ) -> TaskCapability:
+        """Return the one declared capability for a task/stage pair.
+
+        Raises:
+            ValueError: if the pair is unsupported or ambiguously declared.
+        """
+        matches = [
+            capability
+            for capability in self.capabilities
+            if capability.accepts(task, stage)
+        ]
+        if len(matches) != 1:
+            stage_text = "all stages" if stage is None else stage
+            raise ValueError(
+                f"{self.name} does not support task {task!r} for {stage_text}."
+            )
+        return matches[0]
+
+
+def validate_method_specs(specs: Iterable[MethodSpec]) -> None:
+    """Validate a registry and reject repeated canonical method names/paths."""
+    specs = tuple(specs)
+    names = [spec.name for spec in specs]
+    paths = [spec.class_path for spec in specs]
+    if len(names) != len(set(names)):
+        raise ValueError("MethodSpec names must be unique.")
+    if len(paths) != len(set(paths)):
+        raise ValueError("MethodSpec class paths must be unique.")
+
+
+__all__ = [
+    "MethodSpec",
+    "OutputField",
+    "OutputSchema",
+    "SmokeFactory",
+    "Stage",
+    "TaskCapability",
+    "validate_method_specs",
+]

--- a/lightning_uq_box/uq_methods/mc_dropout.py
+++ b/lightning_uq_box/uq_methods/mc_dropout.py
@@ -4,6 +4,7 @@
 """Mc-Dropout module."""
 
 import os
+from collections.abc import Mapping
 from typing import Any, ClassVar
 
 import torch
@@ -11,7 +12,10 @@ from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 from torch import Tensor, nn
 
-from .base import DeterministicModel
+from ._deprecated import warn_legacy_adapter
+from .base import Deterministic, DeterministicModel
+from .method_specs import MCDROPOUT_SPEC
+from .tasks import ClassificationTask, TaskSpec
 from .utils import (
     _get_num_outputs,
     default_classification_metrics,
@@ -133,7 +137,13 @@ class MCDropoutBase(DeterministicModel):
 
 
 class MCDropoutRegression(MCDropoutBase):
-    """MC-Dropout Model for Regression.
+    """Deprecated MC-Dropout regression compatibility adapter.
+
+    .. versionchanged:: 0.4.0
+
+       Use :class:`MCDropout` with :class:`RegressionTask` for new code. This
+       adapter retains its historical constructor, sampling behavior, and
+       state-dict prefixes through 0.4.
 
     If you use this model in your research, please cite the following paper:
 
@@ -166,6 +176,10 @@ class MCDropoutRegression(MCDropoutBase):
             lr_scheduler: learning rate scheduler
                 from the predictive distribution
         """
+        if type(self) is MCDropoutRegression:
+            warn_legacy_adapter(
+                "MCDropoutRegression", "MCDropout(..., task=RegressionTask())"
+            )
         if dropout_layer_names is None:
             dropout_layer_names = []
         super().__init__(
@@ -268,7 +282,13 @@ class MCDropoutRegression(MCDropoutBase):
 
 
 class MCDropoutClassification(MCDropoutBase):
-    """MC-Dropout Model for Classification.
+    """Deprecated MC-Dropout classification compatibility adapter.
+
+    .. versionchanged:: 0.4.0
+
+       Use :class:`MCDropout` with :class:`ClassificationTask` for new code.
+       This adapter preserves its string task argument and state-dict prefixes
+       through 0.4.
 
     If you use this model in your research, please cite the following paper:
 
@@ -301,6 +321,11 @@ class MCDropoutClassification(MCDropoutBase):
             optimizer: optimizer used for training
             lr_scheduler: learning rate scheduler
         """
+        if type(self) is MCDropoutClassification:
+            warn_legacy_adapter(
+                "MCDropoutClassification",
+                "MCDropout(..., task=ClassificationTask(...))",
+            )
         if dropout_layer_names is None:
             dropout_layer_names = []
         assert task in self.valid_tasks
@@ -378,7 +403,14 @@ class MCDropoutClassification(MCDropoutBase):
 
 
 class MCDropoutSegmentation(MCDropoutClassification):
-    """MC-Dropout Model for Segmentation."""
+    """Deprecated MC-Dropout segmentation compatibility adapter.
+
+    .. versionchanged:: 0.4.0
+
+       Use :class:`MCDropout` with :class:`SegmentationTask` for new code.
+       This adapter retains dense prediction persistence and its historical
+       constructor/state-dict surface through 0.4.
+    """
 
     pred_dir_name = "preds"
 
@@ -411,6 +443,10 @@ class MCDropoutSegmentation(MCDropoutClassification):
             lr_scheduler: learning rate scheduler
             save_preds: whether to save predictions
         """
+        if type(self) is MCDropoutSegmentation:
+            warn_legacy_adapter(
+                "MCDropoutSegmentation", "MCDropout(..., task=SegmentationTask(...))"
+            )
         if dropout_layer_names is None:
             dropout_layer_names = []
         self.freeze_backbone = freeze_backbone
@@ -494,6 +530,12 @@ class MCDropoutPxRegression(MCDropoutRegression):
     """MC-Dropout Model for Pixel-wise Regression.
 
     .. versionadded:: 0.2.0
+
+    .. versionchanged:: 0.4.0
+
+       Use :class:`MCDropout` with :class:`PixelRegressionTask` for new code.
+       This adapter preserves dense persistence and the historical state-dict
+       topology through 0.4.
     """
 
     pred_dir_name = "preds"
@@ -525,6 +567,10 @@ class MCDropoutPxRegression(MCDropoutRegression):
             lr_scheduler: learning rate scheduler
             save_preds: whether to save predictions
         """
+        if type(self) is MCDropoutPxRegression:
+            warn_legacy_adapter(
+                "MCDropoutPxRegression", "MCDropout(..., task=PixelRegressionTask())"
+            )
         if dropout_layer_names is None:
             dropout_layer_names = []
         self.freeze_decoder = freeze_decoder
@@ -578,3 +624,227 @@ class MCDropoutPxRegression(MCDropoutRegression):
         """
         if self.save_preds:
             save_image_predictions(outputs, batch_idx, self.pred_dir)
+
+
+class MCDropout(Deterministic):
+    """Canonical MC Dropout method parameterized by an explicit task value.
+
+    The historical ``MCDropoutRegression``, ``MCDropoutClassification``,
+    ``MCDropoutSegmentation``, and ``MCDropoutPxRegression`` classes remain
+    unchanged as 0.4 compatibility entry points.  This class owns stochastic
+    sampling and aggregation while the canonical runtime owns only task
+    handling, metrics, result shaping, and persistence.
+
+    .. versionchanged:: 0.4.0
+
+       MC Dropout now has one canonical method API with an explicit task
+       value. Standard dropout activation and stochastic aggregation remain
+       method-owned; tasks never infer a distribution from output shape.
+    """
+
+    method_spec = MCDROPOUT_SPEC
+
+    def __init__(
+        self,
+        model: nn.Module,
+        num_mc_samples: int,
+        loss_fn: nn.Module,
+        *,
+        task: TaskSpec | Mapping[str, Any] | None = None,
+        dropout_layer_names: list[str] | None = None,
+        burnin_epochs: int = 0,
+        prediction_kind: str = "point",
+        freeze_backbone: bool = False,
+        freeze_decoder: bool = False,
+        optimizer: OptimizerCallable = torch.optim.Adam,
+        lr_scheduler: LRSchedulerCallable | None = None,
+        save_preds: bool = False,
+    ) -> None:
+        """Initialize canonical MC Dropout.
+
+        Args:
+            model: model containing named ``nn.Dropout`` modules.
+            num_mc_samples: number of stochastic forward passes for prediction.
+            loss_fn: method-owned training loss.
+            task: immutable task value or supported task configuration mapping.
+            dropout_layer_names: dropout module names to activate.  ``None``
+                discovers all standard ``nn.Dropout`` modules.
+            burnin_epochs: initial point-loss epochs for regression workflows.
+            prediction_kind: ``"point"`` or explicit ``"gaussian"`` output
+                conversion.  This is method-owned and never guessed by a task.
+            freeze_backbone: freeze the model backbone before training.
+            freeze_decoder: freeze a dense-model decoder before training.
+            optimizer: optimizer factory.
+            lr_scheduler: optional learning-rate scheduler factory.
+            save_preds: persist dense predictions in test hooks.
+        """
+        if num_mc_samples < 1:
+            raise ValueError("num_mc_samples must be at least one.")
+        if prediction_kind not in {"point", "gaussian"}:
+            raise ValueError("prediction_kind must be 'point' or 'gaussian'.")
+        self.num_mc_samples = num_mc_samples
+        self.dropout_layer_names = (
+            list(dropout_layer_names)
+            if dropout_layer_names is not None
+            else find_dropout_layers(model)
+        )
+        self.burnin_epochs = burnin_epochs
+        self.prediction_kind = prediction_kind
+        super().__init__(
+            model,
+            loss_fn,
+            task=task,
+            freeze_backbone=freeze_backbone,
+            freeze_decoder=freeze_decoder,
+            optimizer=optimizer,
+            lr_scheduler=lr_scheduler,
+            save_preds=save_preds,
+        )
+        self.save_hyperparameters(
+            {
+                "num_mc_samples": num_mc_samples,
+                "dropout_layer_names": self.dropout_layer_names,
+                "burnin_epochs": burnin_epochs,
+                "prediction_kind": prediction_kind,
+            }
+        )
+
+    def activate_dropout(self) -> None:
+        """Enable exactly the configured dropout modules for MC prediction."""
+        found: set[str] = set()
+        self.model.train()
+        for name, module in self.model.named_modules():
+            if isinstance(module, nn.modules.batchnorm._BatchNorm):
+                module.eval()
+            if name in self.dropout_layer_names and isinstance(module, nn.Dropout):
+                module.train()
+                found.add(name)
+        if not found:
+            raise UserWarning(
+                "No dropout layers found in model, maybe dropout is implemented "
+                "via specialized layers?"
+            )
+
+    def _samples(self, X: Tensor) -> Tensor:
+        """Return samples with a leading sample axis kept method-local."""
+        self.activate_dropout()
+        with torch.no_grad():
+            samples = [self.model(X) for _ in range(self.num_mc_samples)]
+        if not all(isinstance(sample, Tensor) for sample in samples):
+            raise TypeError("Canonical MCDropout requires Tensor model outputs.")
+        return torch.stack(samples)
+
+    def _regression_payload(self, samples: Tensor) -> dict[str, Tensor]:
+        """Convert sampled regression outputs without a task shape heuristic."""
+        if self.prediction_kind == "gaussian":
+            if samples.ndim < 3 or samples.shape[2] != 2:
+                raise ValueError(
+                    "Gaussian MCDropout requires an explicit two-channel output at axis 1."
+                )
+            means = samples[:, :, 0:1, ...]
+            log_variances = samples[:, :, 1:2, ...]
+            variances = torch.exp(log_variances).clamp_min(1e-6)
+            prediction = means.mean(dim=0)
+            epistemic = means.std(dim=0, correction=0)
+            aleatoric = variances.mean(dim=0).sqrt()
+            return {
+                "pred": prediction,
+                "pred_uct": (epistemic.square() + aleatoric.square()).sqrt(),
+                "epistemic_uct": epistemic,
+                "aleatoric_uct": aleatoric,
+            }
+        prediction = samples.mean(dim=0)
+        epistemic = samples.std(dim=0, correction=0)
+        return {"pred": prediction, "pred_uct": epistemic, "epistemic_uct": epistemic}
+
+    def metric_prediction(self, raw_output: Tensor, stage: str) -> Tensor:
+        """Select the explicit Gaussian mean for regression metrics.
+
+        Point predictions retain every target channel. A Gaussian prediction
+        has method-owned ``[mean, log_variance]`` channels, so only its mean is
+        a valid target-shaped metric input.
+        """
+        if (
+            not isinstance(self.task, ClassificationTask)
+            and self.prediction_kind == "gaussian"
+        ):
+            if raw_output.ndim < 2 or raw_output.shape[1] != 2:
+                raise ValueError(
+                    "Gaussian MCDropout requires an explicit two-channel output at axis 1."
+                )
+            return raw_output[:, 0:1, ...]
+        return super().metric_prediction(raw_output, stage)
+
+    def prediction_payload(self, raw_output: Tensor) -> dict[str, Tensor]:
+        """Convert canonical MC samples to the declared public payload."""
+        if not isinstance(self.task, ClassificationTask):
+            return self._regression_payload(raw_output)
+
+        # ``raw_output`` is [sample, batch, class, ...].  The task determines
+        # the distribution; no output-size inference is used here.
+        mean_logits = raw_output.mean(dim=0)
+        self._validate_raw_output(mean_logits)
+        if self.task.mode == "multilabel":
+            probabilities = torch.sigmoid(raw_output).mean(dim=0)
+            clipped = probabilities.clamp(1e-7, 1 - 1e-7)
+            entropy = -(
+                clipped * clipped.log() + (1 - clipped) * (1 - clipped).log()
+            ).sum(dim=1)
+        elif self.task.mode == "binary" and self.task.binary_encoding == "one_logit":
+            probabilities = torch.sigmoid(raw_output).mean(dim=0)
+            clipped = probabilities.clamp(1e-7, 1 - 1e-7)
+            entropy = -(
+                clipped * clipped.log() + (1 - clipped) * (1 - clipped).log()
+            ).select(1, 0)
+        else:
+            probabilities = torch.softmax(raw_output, dim=2).mean(dim=0).clamp_min(1e-7)
+            entropy = -(probabilities * probabilities.log()).sum(dim=1)
+        return {
+            "pred": probabilities,
+            "pred_uct": entropy,
+            "logits": raw_output.movedim(0, -1),
+        }
+
+    def predict_step(
+        self, X: Tensor, batch_idx: int = 0, dataloader_idx: int = 0
+    ) -> dict[str, Tensor]:
+        """Produce an MC-aggregated, contract-checked prediction payload."""
+        del batch_idx, dataloader_idx
+        payload = self.prediction_payload(self._samples(X))
+        self.output_schema.validate_payload(payload)
+        return payload
+
+    def training_step(
+        self, batch: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> Tensor:
+        """Train with method-owned burn-in while retaining canonical metrics."""
+        if self.current_epoch >= self.burnin_epochs or isinstance(
+            self.task, ClassificationTask
+        ):
+            return super().training_step(batch, batch_idx, dataloader_idx)
+        raw_output = self.forward(batch[self.input_key])
+        if not isinstance(raw_output, Tensor):
+            raise TypeError("Canonical MCDropout requires a Tensor model output.")
+        metric_output = self.metric_prediction(raw_output, "train")
+        target = self.task_runtime.target_for_loss(batch[self.target_key], raw_output)
+        loss = nn.functional.mse_loss(metric_output, target)
+        self.task_runtime.update_metrics("train", metric_output, batch[self.target_key])
+        self.log("train_loss", loss, batch_size=batch[self.input_key].shape[0])
+        return loss
+
+    def test_step(
+        self, batch: dict[str, Tensor], batch_idx: int, dataloader_idx: int = 0
+    ) -> dict[str, Any]:
+        """Test from one canonical MC sample stack rather than two forwards."""
+        del batch_idx, dataloader_idx
+        samples = self._samples(batch[self.input_key])
+        payload = self.prediction_payload(samples)
+        self.output_schema.validate_payload(payload)
+        self.task_runtime.update_metrics(
+            "test",
+            self.metric_prediction(samples.mean(dim=0), "test"),
+            batch[self.target_key],
+        )
+        return self.task_runtime.test_result(
+            payload, batch, input_key=self.input_key, target_key=self.target_key
+        )

--- a/lightning_uq_box/uq_methods/method_specs.py
+++ b/lightning_uq_box/uq_methods/method_specs.py
@@ -1,0 +1,326 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Checked-in capability inventory for canonical UQ methods.
+
+Only methods that have crossed the canonical task boundary appear here.  The
+legacy class matrix remains intentionally absent until a method is migrated;
+that prevents advertising an unsupported method/task combination.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import replace
+
+import torch
+from torch import Tensor, nn
+
+from .contracts import (
+    MethodSpec,
+    OutputField,
+    OutputSchema,
+    TaskCapability,
+    validate_method_specs,
+)
+from .tasks import (
+    ClassificationTask,
+    PixelRegressionTask,
+    RegressionTask,
+    SegmentationTask,
+)
+
+
+def _linear_smoke() -> tuple[nn.Module, dict[str, Tensor]]:
+    """Build a CPU regression smoke fixture without test-package imports."""
+    return nn.Linear(2, 1), {"input": torch.zeros(2, 2), "target": torch.zeros(2, 1)}
+
+
+def _classification_smoke() -> tuple[nn.Module, dict[str, Tensor]]:
+    """Build a CPU classification smoke fixture."""
+    return nn.Linear(2, 3), {
+        "input": torch.zeros(2, 2),
+        "target": torch.zeros(2, dtype=torch.long),
+    }
+
+
+def _binary_smoke() -> tuple[nn.Module, dict[str, Tensor]]:
+    """Build a one-logit binary-classification smoke fixture."""
+    return nn.Linear(2, 1), {"input": torch.zeros(2, 2), "target": torch.zeros(2)}
+
+
+def _pixel_smoke() -> tuple[nn.Module, dict[str, Tensor]]:
+    """Build a dense prediction smoke fixture."""
+    return nn.Conv2d(1, 1, kernel_size=1), {
+        "input": torch.zeros(2, 1, 4, 4),
+        "target": torch.zeros(2, 1, 4, 4),
+    }
+
+
+REGRESSION_SCHEMA = OutputSchema(
+    task_type=RegressionTask,
+    raw_axes=("batch", "target"),
+    metric_input="raw_prediction",
+    fields=(OutputField(name="pred", axes=("batch", "target")),),
+)
+PIXEL_REGRESSION_SCHEMA = OutputSchema(
+    task_type=PixelRegressionTask,
+    raw_axes=("batch", "channel", "height", "width"),
+    metric_input="raw_prediction",
+    fields=(OutputField(name="pred", axes=("batch", "channel", "height", "width")),),
+)
+CLASSIFICATION_SCHEMA = OutputSchema(
+    task_type=ClassificationTask,
+    modes=frozenset({"multiclass", "multilabel"}),
+    raw_axes=("batch", "class"),
+    metric_input="logits",
+    fields=(
+        OutputField(name="pred", axes=("batch", "class")),
+        OutputField(name="pred_uct", axes=("batch",)),
+        OutputField(name="logits", axes=("batch", "class")),
+    ),
+    uncertainty_fields=frozenset({"pred_uct"}),
+)
+BINARY_ONE_LOGIT_SCHEMA = OutputSchema(
+    task_type=ClassificationTask,
+    modes=frozenset({"binary"}),
+    binary_encoding="one_logit",
+    raw_axes=("batch", "class"),
+    metric_input="logits",
+    fields=(
+        OutputField(name="pred", axes=("batch", "class")),
+        OutputField(name="pred_uct", axes=("batch",)),
+        OutputField(name="logits", axes=("batch", "class")),
+    ),
+    uncertainty_fields=frozenset({"pred_uct"}),
+)
+BINARY_TWO_LOGIT_SCHEMA = OutputSchema(
+    task_type=ClassificationTask,
+    modes=frozenset({"binary"}),
+    binary_encoding="two_logit",
+    raw_axes=("batch", "class"),
+    metric_input="logits",
+    fields=(
+        OutputField(name="pred", axes=("batch", "class")),
+        OutputField(name="pred_uct", axes=("batch",)),
+        OutputField(name="logits", axes=("batch", "class")),
+    ),
+    uncertainty_fields=frozenset({"pred_uct"}),
+)
+SEGMENTATION_SCHEMA = OutputSchema(
+    task_type=SegmentationTask,
+    modes=frozenset({"multiclass", "multilabel"}),
+    raw_axes=("batch", "class", "height", "width"),
+    metric_input="logits",
+    fields=(
+        OutputField(name="pred", axes=("batch", "class", "height", "width")),
+        OutputField(name="pred_uct", axes=("batch", "height", "width")),
+        OutputField(name="logits", axes=("batch", "class", "height", "width")),
+    ),
+    uncertainty_fields=frozenset({"pred_uct"}),
+)
+SEGMENTATION_BINARY_ONE_LOGIT_SCHEMA = OutputSchema(
+    task_type=SegmentationTask,
+    modes=frozenset({"binary"}),
+    binary_encoding="one_logit",
+    raw_axes=("batch", "class", "height", "width"),
+    metric_input="logits",
+    fields=(
+        OutputField(name="pred", axes=("batch", "class", "height", "width")),
+        OutputField(name="pred_uct", axes=("batch", "height", "width")),
+        OutputField(name="logits", axes=("batch", "class", "height", "width")),
+    ),
+    uncertainty_fields=frozenset({"pred_uct"}),
+)
+SEGMENTATION_BINARY_TWO_LOGIT_SCHEMA = OutputSchema(
+    task_type=SegmentationTask,
+    modes=frozenset({"binary"}),
+    binary_encoding="two_logit",
+    raw_axes=("batch", "class", "height", "width"),
+    metric_input="logits",
+    fields=(
+        OutputField(name="pred", axes=("batch", "class", "height", "width")),
+        OutputField(name="pred_uct", axes=("batch", "height", "width")),
+        OutputField(name="logits", axes=("batch", "class", "height", "width")),
+    ),
+    uncertainty_fields=frozenset({"pred_uct"}),
+)
+
+
+DETERMINISTIC_SPEC = MethodSpec(
+    name="Deterministic",
+    class_path="lightning_uq_box.uq_methods.Deterministic",
+    capabilities=(
+        TaskCapability(
+            task_type=RegressionTask,
+            schema=REGRESSION_SCHEMA,
+            smoke_factory_id="regression",
+            test_id="tests/uq_methods/test_task_method_base.py",
+            config_path="tests/configs/regression/deterministic_canonical.yaml",
+            writer="csv",
+            checkpoint_fixture_id="constructed_module_strict",
+        ),
+        TaskCapability(
+            task_type=PixelRegressionTask,
+            schema=PIXEL_REGRESSION_SCHEMA,
+            smoke_factory_id="pixel_regression",
+            test_id="tests/uq_methods/test_task_method_base.py",
+            config_path="tests/configs/pixelwise_regression/deterministic_canonical.yaml",
+            writer="hdf5",
+            checkpoint_fixture_id="constructed_module_strict",
+        ),
+        TaskCapability(
+            task_type=ClassificationTask,
+            modes=frozenset({"multiclass", "multilabel"}),
+            schema=CLASSIFICATION_SCHEMA,
+            smoke_factory_id="classification",
+            test_id="tests/uq_methods/test_task_method_base.py",
+            config_path="tests/configs/classification/deterministic_canonical.yaml",
+            writer="csv",
+            checkpoint_fixture_id="constructed_module_strict",
+        ),
+        TaskCapability(
+            task_type=ClassificationTask,
+            modes=frozenset({"binary"}),
+            schema=BINARY_ONE_LOGIT_SCHEMA,
+            smoke_factory_id="binary",
+            test_id="tests/uq_methods/test_task_method_base.py",
+            config_path="tests/configs/classification/deterministic_canonical.yaml",
+            writer="csv",
+            checkpoint_fixture_id="constructed_module_strict",
+        ),
+        TaskCapability(
+            task_type=ClassificationTask,
+            modes=frozenset({"binary"}),
+            schema=BINARY_TWO_LOGIT_SCHEMA,
+            smoke_factory_id="classification",
+            test_id="tests/uq_methods/test_task_method_base.py",
+            config_path="tests/configs/classification/deterministic_canonical.yaml",
+            writer="csv",
+            checkpoint_fixture_id="constructed_module_strict",
+        ),
+        TaskCapability(
+            task_type=SegmentationTask,
+            modes=frozenset({"multiclass", "multilabel"}),
+            schema=SEGMENTATION_SCHEMA,
+            smoke_factory_id="segmentation",
+            test_id="tests/uq_methods/test_task_method_base.py",
+            config_path="tests/configs/image_segmentation/deterministic_canonical.yaml",
+            writer="hdf5",
+            checkpoint_fixture_id="constructed_module_strict",
+        ),
+        TaskCapability(
+            task_type=SegmentationTask,
+            modes=frozenset({"binary"}),
+            schema=SEGMENTATION_BINARY_ONE_LOGIT_SCHEMA,
+            smoke_factory_id="segmentation",
+            test_id="tests/uq_methods/test_task_method_base.py",
+            config_path="tests/configs/image_segmentation/deterministic_canonical.yaml",
+            writer="hdf5",
+            checkpoint_fixture_id="constructed_module_strict",
+        ),
+        TaskCapability(
+            task_type=SegmentationTask,
+            modes=frozenset({"binary"}),
+            schema=SEGMENTATION_BINARY_TWO_LOGIT_SCHEMA,
+            smoke_factory_id="segmentation",
+            test_id="tests/uq_methods/test_task_method_base.py",
+            config_path="tests/configs/image_segmentation/deterministic_canonical.yaml",
+            writer="hdf5",
+            checkpoint_fixture_id="constructed_module_strict",
+        ),
+    ),
+    smoke_factories={
+        "regression": _linear_smoke,
+        "pixel_regression": _pixel_smoke,
+        "classification": _classification_smoke,
+        "binary": _binary_smoke,
+        "segmentation": _pixel_smoke,
+    },
+    lifecycle_notes="The model is attached before the eager TaskRuntime is created.",
+    checkpoint_fixture_id="constructed_module_strict",
+)
+
+
+def _sampling_schema(schema: OutputSchema) -> OutputSchema:
+    """Extend a deterministic schema with the sample axis MC Dropout exposes."""
+    fields = []
+    uncertainty_fields = schema.uncertainty_fields
+    for output_field in schema.fields:
+        axes = output_field.axes
+        if output_field.name == "logits":
+            axes = (*axes, "sample")
+        fields.append(replace(output_field, axes=axes))
+    if schema.task_type in {RegressionTask, PixelRegressionTask}:
+        pred_axes = next(field.axes for field in schema.fields if field.name == "pred")
+        fields.extend(
+            (
+                OutputField(name="pred_uct", axes=pred_axes),
+                OutputField(name="epistemic_uct", axes=pred_axes),
+                OutputField(name="aleatoric_uct", axes=pred_axes, required=False),
+            )
+        )
+        uncertainty_fields = frozenset(
+            {*schema.uncertainty_fields, "pred_uct", "epistemic_uct", "aleatoric_uct"}
+        )
+    return replace(
+        schema,
+        fields=tuple(fields),
+        raw_axes=(*schema.raw_axes, "sample"),
+        uncertainty_fields=uncertainty_fields,
+    )
+
+
+MCDROPOUT_SPEC = MethodSpec(
+    name="MCDropout",
+    class_path="lightning_uq_box.uq_methods.MCDropout",
+    capabilities=tuple(
+        replace(
+            capability,
+            schema=_sampling_schema(capability.schema),
+            config_path=capability.config_path.replace(
+                "deterministic_canonical", "mc_dropout_canonical"
+            ),
+        )
+        for capability in DETERMINISTIC_SPEC.capabilities
+    ),
+    smoke_factories=DETERMINISTIC_SPEC.smoke_factories,
+    lifecycle_notes=(
+        "Dropout activation and Monte-Carlo aggregation remain method-owned; "
+        "the eager runtime is created after the model is attached."
+    ),
+    checkpoint_fixture_id="constructed_module_strict",
+)
+
+
+def iter_method_specs() -> Iterator[MethodSpec]:
+    """Yield every current canonical method specification."""
+    yield DETERMINISTIC_SPEC
+    yield MCDROPOUT_SPEC
+
+
+def get_method_spec(name: str) -> MethodSpec:
+    """Return a canonical method spec by public canonical name."""
+    for spec in iter_method_specs():
+        if spec.name == name:
+            return spec
+    raise KeyError(f"Unknown canonical method: {name}")
+
+
+validate_method_specs(iter_method_specs())
+
+
+__all__ = [
+    "BINARY_ONE_LOGIT_SCHEMA",
+    "BINARY_TWO_LOGIT_SCHEMA",
+    "CLASSIFICATION_SCHEMA",
+    "DETERMINISTIC_SPEC",
+    "MCDROPOUT_SPEC",
+    "PIXEL_REGRESSION_SCHEMA",
+    "REGRESSION_SCHEMA",
+    "SEGMENTATION_BINARY_ONE_LOGIT_SCHEMA",
+    "SEGMENTATION_BINARY_TWO_LOGIT_SCHEMA",
+    "SEGMENTATION_SCHEMA",
+    "get_method_spec",
+    "iter_method_specs",
+]

--- a/lightning_uq_box/uq_methods/task_runtime.py
+++ b/lightning_uq_box/uq_methods/task_runtime.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Private runtime services for canonical task-aware methods.
+
+``TaskRuntime`` is deliberately a child module so Lightning moves it with its
+parent and hook ownership is unambiguous.  Metric collections are deliberately
+kept out of the module registry: metric state belongs to a run, never to a
+model checkpoint.  The runtime itself therefore contributes no persistent
+state-dict keys.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from lightning.pytorch.utilities.types import STEP_OUTPUT
+from torch import Tensor, nn
+from torchmetrics import MetricCollection
+
+from .contracts import OutputSchema
+from .tasks import (
+    ClassificationTask,
+    PixelRegressionTask,
+    RegressionTask,
+    SegmentationTask,
+    TaskSpec,
+)
+from .utils import (
+    default_classification_metrics,
+    default_px_regression_metrics,
+    default_regression_metrics,
+    default_segmentation_metrics,
+    save_classification_predictions,
+    save_image_predictions,
+    save_regression_predictions,
+)
+
+
+class TaskRuntime(nn.Module):
+    """Run-only task handling, metrics, result shaping, and persistence."""
+
+    def __init__(self, task: TaskSpec, schema: OutputSchema, num_outputs: int) -> None:
+        """Initialize the eager task runtime.
+
+        Args:
+            task: normalized task semantics.
+            schema: selected method/task output contract.
+            num_outputs: number of model output channels/classes.
+        """
+        super().__init__()
+        self.task = task
+        self.schema = schema
+        self.num_outputs = num_outputs
+        # Assign outside nn.Module.__setattr__: torchmetrics state must not
+        # become task_runtime.* checkpoint keys.
+        object.__setattr__(
+            self,
+            "_metrics",
+            {
+                "train": self._make_metrics("train"),
+                "validate": self._make_metrics("val"),
+                "test": self._make_metrics("test"),
+            },
+        )
+
+    def _make_metrics(self, prefix: str) -> MetricCollection:
+        """Create task-appropriate metrics for one lifecycle stage."""
+        if isinstance(self.task, PixelRegressionTask):
+            return default_px_regression_metrics(prefix)
+        if isinstance(self.task, RegressionTask):
+            return default_regression_metrics(prefix, include_r2=False)
+        if isinstance(self.task, SegmentationTask):
+            return default_segmentation_metrics(
+                prefix, self.task.mode, self.num_outputs
+            )
+        if isinstance(self.task, ClassificationTask):
+            return default_classification_metrics(
+                prefix, self.task.mode, self.num_outputs
+            )
+        raise TypeError(f"Unsupported task runtime: {self.task!r}")
+
+    @property
+    def train_metrics(self) -> MetricCollection:
+        """Metrics accumulated while training."""
+        return self._metrics["train"]
+
+    @property
+    def val_metrics(self) -> MetricCollection:
+        """Metrics accumulated while validating."""
+        return self._metrics["validate"]
+
+    @property
+    def test_metrics(self) -> MetricCollection:
+        """Metrics accumulated while testing."""
+        return self._metrics["test"]
+
+    def normalize_target(self, target: Tensor) -> Tensor:
+        """Normalize only an explicit singleton class axis.
+
+        Batch dimensions are never squeezed.  This is the important distinction
+        from the legacy ``squeeze(-1)`` behavior: a one-item batch remains a
+        batch, and a spatial width of one is not accidentally removed.
+        """
+        if isinstance(self.task, ClassificationTask) and self.task.mode == "multiclass":
+            if target.ndim >= 2 and target.shape[1] == 1:
+                return target.select(1, 0)
+        if (
+            isinstance(self.task, ClassificationTask)
+            and self.task.mode == "binary"
+            and self.task.binary_encoding == "one_logit"
+            and target.ndim >= 2
+            and target.shape[1] == 1
+        ):
+            return target.select(1, 0)
+        return target
+
+    def target_for_loss(self, target: Tensor, raw_output: Tensor) -> Tensor:
+        """Return the target shape required by the explicit task loss contract.
+
+        BCE with one-logit outputs is the one case where metric targets and
+        loss targets intentionally differ: metrics consume ``[batch, ...]``
+        after removing the class axis, while BCE consumes the matching
+        ``[batch, 1, ...]`` shape.  The axis insertion is driven by the task's
+        declared encoding, never by a generic final-axis squeeze.
+        """
+        if (
+            isinstance(self.task, ClassificationTask)
+            and self.task.mode == "binary"
+            and self.task.binary_encoding == "one_logit"
+            and target.ndim == raw_output.ndim - 1
+        ):
+            return target.unsqueeze(1)
+        if isinstance(self.task, ClassificationTask) and self.task.mode == "multiclass":
+            return self.normalize_target(target)
+        return target
+
+    def update_metrics(self, stage: str, prediction: Tensor, target: Tensor) -> None:
+        """Update metrics for a batch, including batches of size one."""
+        metrics = self._metrics[stage]
+        # The collections are intentionally not registered child modules, so
+        # explicitly move their non-persistent state before their first update.
+        metrics.to(prediction.device)
+        metrics.update(prediction, self.normalize_target(target))
+
+    def compute_and_reset(self, stage: str) -> dict[str, Tensor]:
+        """Compute and reset metrics for an epoch boundary."""
+        metrics = self._metrics[stage]
+        computed = metrics.compute()
+        metrics.reset()
+        return computed
+
+    def test_result(
+        self,
+        payload: Mapping[str, Tensor],
+        batch: Mapping[str, Any],
+        *,
+        input_key: str,
+        target_key: str,
+    ) -> dict[str, Any]:
+        """Copy a prediction payload and add a normalized target/auxiliary data."""
+        result: dict[str, Any] = {
+            key: value.detach().cpu().clone() for key, value in payload.items()
+        }
+        target = batch[target_key]
+        if not isinstance(target, Tensor):
+            raise TypeError(f"Batch target '{target_key}' must be a Tensor.")
+        result[target_key] = self.normalize_target(target).detach().cpu().clone()
+        for key, value in batch.items():
+            if key in {input_key, target_key}:
+                continue
+            if isinstance(value, Tensor):
+                result[key] = value.detach().cpu().clone()
+            else:
+                result[key] = value
+        return result
+
+    def on_test_start(self, root_dir: str, save_predictions: bool) -> str | None:
+        """Create the dense-prediction directory when required."""
+        if not save_predictions or not isinstance(
+            self.task, SegmentationTask | PixelRegressionTask
+        ):
+            return None
+        path = os.path.join(root_dir, "preds")
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def write_test_result(
+        self,
+        outputs: STEP_OUTPUT,
+        *,
+        root_dir: str,
+        batch_idx: int,
+        save_predictions: bool,
+        prediction_dir: str | None,
+    ) -> None:
+        """Persist a copied test result according to the task contract."""
+        if not isinstance(outputs, dict):
+            return
+        copied = {
+            key: value.clone() if isinstance(value, Tensor) else value
+            for key, value in outputs.items()
+        }
+        if isinstance(self.task, SegmentationTask | PixelRegressionTask):
+            if save_predictions and prediction_dir is not None:
+                save_image_predictions(copied, batch_idx, prediction_dir)
+            return
+        if isinstance(self.task, RegressionTask):
+            save_regression_predictions(copied, os.path.join(root_dir, "preds.csv"))
+            return
+        if isinstance(self.task, ClassificationTask):
+            save_classification_predictions(
+                copied,
+                os.path.join(root_dir, "preds.csv"),
+                task=self.task.mode,
+                binary_encoding=self.task.binary_encoding,
+            )
+
+
+__all__ = ["TaskRuntime"]

--- a/lightning_uq_box/uq_methods/tasks.py
+++ b/lightning_uq_box/uq_methods/tasks.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Serializable task descriptions used by canonical UQ methods.
+
+Task descriptions deliberately contain *only* semantic task information.  They
+are not ``nn.Module`` instances and are never saved in a checkpoint as Python
+objects.  :func:`normalize_task` accepts the two configuration dialects used by
+Lightning-UQ-Box and turns them into one of the immutable values below.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, fields
+from typing import Any, ClassVar, Literal
+from warnings import warn
+
+TaskMode = Literal["binary", "multiclass", "multilabel"]
+BinaryEncoding = Literal["one_logit", "two_logit"]
+
+_TASK_VERSION = 1
+_TASK_MODULE = "lightning_uq_box.uq_methods.tasks"
+
+
+@dataclass(frozen=True, kw_only=True)
+class TaskSpec:
+    """Base class for a task value.
+
+    Subclasses define the public fields that may be represented in a config or
+    checkpoint.  The implementation intentionally uses an allow-list instead
+    of importing arbitrary class paths from untrusted checkpoint data.
+    """
+
+    class_path: ClassVar[str]
+
+    def to_mapping(self) -> dict[str, Any]:
+        """Return the stable, JSON-serializable checkpoint representation."""
+        return {
+            "version": _TASK_VERSION,
+            "class_path": self.class_path,
+            "init_args": asdict(self),
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> TaskSpec:
+        """Construct an allow-listed task from a config/checkpoint mapping.
+
+        Args:
+            value: a versioned serialized task, a LightningCLI
+                ``class_path``/``init_args`` mapping, or a Hydra
+                ``_target_`` mapping.
+
+        Returns:
+            the normalized immutable task value.
+
+        Raises:
+            TypeError: if ``value`` is not a supported task mapping.
+            ValueError: if the mapping has unknown or missing fields.
+        """
+        return task_from_mapping(value)
+
+
+@dataclass(frozen=True, kw_only=True)
+class RegressionTask(TaskSpec):
+    """A vector or scalar regression task."""
+
+    class_path: ClassVar[str] = f"{_TASK_MODULE}.RegressionTask"
+
+
+@dataclass(frozen=True, kw_only=True)
+class ClassificationTask(TaskSpec):
+    """A classification task with an explicit probability encoding.
+
+    ``binary_encoding`` matters only for the binary mode.  Keeping it in the
+    value prevents an output conversion from guessing a distribution based on
+    a last-axis size.  A one-logit binary task uses BCE/sigmoid; a two-logit
+    binary task uses CE/softmax.
+    """
+
+    mode: TaskMode = "multiclass"
+    binary_encoding: BinaryEncoding = "one_logit"
+
+    class_path: ClassVar[str] = f"{_TASK_MODULE}.ClassificationTask"
+
+    def __post_init__(self) -> None:
+        """Validate modes and normalize the historical misspelling."""
+        mode = self.mode
+        if mode == "multilable":  # type: ignore[comparison-overlap]
+            warn(
+                "'multilable' is deprecated; use 'multilabel'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            object.__setattr__(self, "mode", "multilabel")
+            mode = "multilabel"
+        if mode not in {"binary", "multiclass", "multilabel"}:
+            raise ValueError(
+                "ClassificationTask.mode must be 'binary', 'multiclass', or "
+                f"'multilabel', got {mode!r}."
+            )
+        if self.binary_encoding not in {"one_logit", "two_logit"}:
+            raise ValueError(
+                "ClassificationTask.binary_encoding must be 'one_logit' or "
+                f"'two_logit', got {self.binary_encoding!r}."
+            )
+
+
+@dataclass(frozen=True, kw_only=True)
+class SegmentationTask(ClassificationTask):
+    """A dense classification task with class axis one."""
+
+    class_path: ClassVar[str] = f"{_TASK_MODULE}.SegmentationTask"
+
+
+@dataclass(frozen=True, kw_only=True)
+class PixelRegressionTask(TaskSpec):
+    """A dense regression task with channel axis one."""
+
+    class_path: ClassVar[str] = f"{_TASK_MODULE}.PixelRegressionTask"
+
+
+_TASK_TYPES: dict[str, type[TaskSpec]] = {
+    RegressionTask.class_path: RegressionTask,
+    ClassificationTask.class_path: ClassificationTask,
+    SegmentationTask.class_path: SegmentationTask,
+    PixelRegressionTask.class_path: PixelRegressionTask,
+    # The package-level exports are supported config entry points.  They map
+    # to the same fixed allow-list and serialize back to the canonical module
+    # path above, so accepting them does not permit arbitrary imports.
+    "lightning_uq_box.uq_methods.RegressionTask": RegressionTask,
+    "lightning_uq_box.uq_methods.ClassificationTask": ClassificationTask,
+    "lightning_uq_box.uq_methods.SegmentationTask": SegmentationTask,
+    "lightning_uq_box.uq_methods.PixelRegressionTask": PixelRegressionTask,
+}
+
+
+def _task_fields(task_type: type[TaskSpec]) -> set[str]:
+    return {field.name for field in fields(task_type) if field.init}
+
+
+def task_from_mapping(value: Mapping[str, Any]) -> TaskSpec:
+    """Deserialize an allow-listed task mapping.
+
+    This is intentionally strict.  In particular it rejects a checkpoint that
+    claims to be a newer representation or names a Python path outside of this
+    module rather than importing that path dynamically.
+    """
+    raw = dict(value)
+    if "_target_" in raw:
+        allowed = {"_target_", *(_task_fields_from_raw_target(raw))}
+        unknown = set(raw) - allowed
+        if unknown:
+            raise ValueError(f"Unknown task fields: {sorted(unknown)}")
+        class_path = raw.pop("_target_")
+        init_args = raw
+    elif "class_path" in raw and "init_args" in raw:
+        allowed = {"class_path", "init_args", "version"}
+        unknown = set(raw) - allowed
+        if unknown:
+            raise ValueError(f"Unknown task mapping fields: {sorted(unknown)}")
+        version = raw.get("version")
+        if version is not None and version != _TASK_VERSION:
+            raise ValueError(
+                f"Unsupported task serialization version {version!r}; "
+                f"expected {_TASK_VERSION}."
+            )
+        class_path = raw["class_path"]
+        init_args = raw["init_args"]
+    else:
+        raise TypeError(
+            "A task mapping must use Hydra '_target_' or LightningCLI "
+            "'class_path' and 'init_args' keys."
+        )
+
+    if not isinstance(class_path, str) or class_path not in _TASK_TYPES:
+        raise ValueError(f"Unsupported task class_path: {class_path!r}.")
+    if not isinstance(init_args, Mapping):
+        raise TypeError("task.init_args must be a mapping.")
+
+    task_type = _TASK_TYPES[class_path]
+    args = dict(init_args)
+    unknown_args = set(args) - _task_fields(task_type)
+    if unknown_args:
+        raise ValueError(f"Unknown task init_args: {sorted(unknown_args)}")
+    return task_type(**args)
+
+
+def _task_fields_from_raw_target(value: Mapping[str, Any]) -> set[str]:
+    """Return accepted Hydra task fields without importing a target."""
+    class_path = value.get("_target_")
+    if not isinstance(class_path, str) or class_path not in _TASK_TYPES:
+        raise ValueError(f"Unsupported task class_path: {class_path!r}.")
+    return _task_fields(_TASK_TYPES[class_path])
+
+
+def normalize_task(
+    task: TaskSpec | Mapping[str, Any] | None, *, default: TaskSpec | None = None
+) -> TaskSpec | None:
+    """Normalize a public task argument without providing a mutable default.
+
+    Args:
+        task: a task value, supported config mapping, or ``None``.
+        default: a freshly constructed default supplied by the owning method.
+
+    Returns:
+        the supplied task, its deserialized mapping, or ``default``.
+    """
+    if task is None:
+        return default
+    if isinstance(task, TaskSpec):
+        return task
+    if isinstance(task, Mapping):
+        return task_from_mapping(task)
+    raise TypeError("task must be a TaskSpec, supported mapping, or None.")
+
+
+__all__ = [
+    "BinaryEncoding",
+    "ClassificationTask",
+    "PixelRegressionTask",
+    "RegressionTask",
+    "SegmentationTask",
+    "TaskMode",
+    "TaskSpec",
+    "normalize_task",
+    "task_from_mapping",
+]

--- a/lightning_uq_box/uq_methods/utils.py
+++ b/lightning_uq_box/uq_methods/utils.py
@@ -3,6 +3,7 @@
 
 """Utilities for UQ-Method Implementations."""
 
+import json
 import os
 from collections import OrderedDict
 from collections.abc import Callable
@@ -75,16 +76,19 @@ def identity(x: Tensor, dim: int | None = None) -> Tensor:
     return x
 
 
-def default_regression_metrics(prefix: str):
-    """Return a set of default regression metrics."""
-    return MetricCollection(
-        {
-            "RMSE": MeanSquaredError(squared=False),
-            "MAE": MeanAbsoluteError(),
-            "R2": R2Score(),
-        },
-        prefix=prefix,
-    )
+def default_regression_metrics(prefix: str, include_r2: bool = True):
+    """Return a set of default regression metrics.
+
+    Args:
+        prefix: prefix prepended to metric names.
+        include_r2: include R² when a lifecycle guarantees at least two
+            accumulated observations.  Canonical task runtimes leave it out so
+            a valid one-item batch can be counted and completed.
+    """
+    metrics = {"RMSE": MeanSquaredError(squared=False), "MAE": MeanAbsoluteError()}
+    if include_r2:
+        metrics["R2"] = R2Score()
+    return MetricCollection(metrics, prefix=prefix)
 
 
 def default_px_regression_metrics(prefix: str):
@@ -115,6 +119,18 @@ def default_classification_metrics(prefix: str, task: str, num_classes: int):
             {
                 "Acc": Accuracy(task=task, num_labels=num_classes),
                 "F1Score": F1Score(task=task, num_labels=num_classes),
+            },
+            prefix=prefix,
+        )
+    if task == "binary":
+        # EmpiricalCoverage is defined over a class-set axis and cannot be
+        # updated from the one-logit ``[batch]`` representation.  Omitting it
+        # here lets canonical one-logit BCE models count every batch,
+        # including batch size one, rather than skipping those batches.
+        return MetricCollection(
+            {
+                "Acc": Accuracy(task="binary"),
+                "Calibration": CalibrationError(task="binary"),
             },
             prefix=prefix,
         )
@@ -210,6 +226,7 @@ def process_classification_prediction(
     aggregate_fn: Callable = torch.mean,
     eps: float = 1e-7,
     task: str = "multiclass",
+    binary_encoding: str = "two_logit",
 ) -> dict[str, Tensor]:
     """Process classification predictions.
 
@@ -219,11 +236,20 @@ def process_classification_prediction(
     sigmoid is applied per label and the uncertainty is the sum of the
     per-label binary entropies.
 
+    .. versionchanged:: 0.4.0
+
+       Canonical callers can pass an explicit one-logit or two-logit binary
+       encoding. The default remains two-logit to preserve legacy callers.
+
     Args:
         logits: prediction logits tensor of shape [batch_size, num_classes, num_samples]
         aggregate_fn: function to aggregate over the samples
         eps: small value to prevent log of 0
         task: one of "binary", "multiclass" or "multilabel"
+        binary_encoding: binary probability encoding; canonical callers pass
+            ``"one_logit"`` for BCE/sigmoid and ``"two_logit"`` for
+            CE/softmax.  The legacy default preserves historical two-logit
+            behavior.
 
     Returns:
         dictionary with aggregated class probabilities [batch_size, num_classes]
@@ -234,6 +260,12 @@ def process_classification_prediction(
         mean = mean.clamp(eps, 1 - eps)
         entropy = -(mean * mean.log() + (1 - mean) * (1 - mean).log()).sum(dim=-1)
         return {"pred": mean, "pred_uct": entropy, "logits": logits}
+
+    if task == "binary" and binary_encoding == "one_logit":
+        mean = aggregate_fn(torch.sigmoid(logits), dim=-1)
+        mean = mean.clamp(eps, 1 - eps)
+        entropy = -(mean * mean.log() + (1 - mean) * (1 - mean).log())
+        return {"pred": mean, "pred_uct": entropy.squeeze(1), "logits": logits}
 
     mean = aggregate_fn(nn.functional.softmax(logits, dim=1), dim=-1)
     # prevent log of 0 -> nan
@@ -247,6 +279,7 @@ def process_segmentation_prediction(
     aggregate_fn: Callable = torch.mean,
     eps: float = 1e-7,
     task: str = "multiclass",
+    binary_encoding: str = "two_logit",
 ) -> dict[str, Tensor]:
     """Process segmentation predictions.
 
@@ -256,12 +289,21 @@ def process_segmentation_prediction(
     sigmoid is applied per label and the uncertainty is the sum of the
     per-label binary entropies.
 
+    .. versionchanged:: 0.4.0
+
+       Canonical callers can pass an explicit one-logit or two-logit binary
+       encoding. The default remains two-logit to preserve legacy callers.
+
     Args:
         logits: prediction logits tensor of shape
             [batch_size, num_classes, height, width, num_samples]
         aggregate_fn: function to aggregate over the samples
         eps: small value to prevent log of 0
         task: one of "binary", "multiclass" or "multilabel"
+        binary_encoding: binary probability encoding; canonical callers pass
+            ``"one_logit"`` for BCE/sigmoid and ``"two_logit"`` for
+            CE/softmax.  The legacy default preserves historical two-logit
+            behavior.
 
     Returns:
         dictionary with pixel class probabilities
@@ -272,6 +314,12 @@ def process_segmentation_prediction(
         mean = aggregate_fn(torch.sigmoid(logits), dim=-1)
         mean = mean.clamp(eps, 1 - eps)
         entropy = -(mean * mean.log() + (1 - mean) * (1 - mean).log()).sum(dim=1)
+        return {"pred": mean, "pred_uct": entropy, "logits": logits}
+
+    if task == "binary" and binary_encoding == "one_logit":
+        mean = aggregate_fn(torch.sigmoid(logits), dim=-1)
+        mean = mean.clamp(eps, 1 - eps)
+        entropy = -(mean * mean.log() + (1 - mean) * (1 - mean).log()).squeeze(1)
         return {"pred": mean, "pred_uct": entropy, "logits": logits}
 
     mean = aggregate_fn(nn.functional.softmax(logits, dim=1), dim=-1)
@@ -287,8 +335,59 @@ def change_inplace_activation(module):
         module.inplace = False
 
 
+def _distributed_path(path: str) -> str:
+    """Return a rank-sharded path and publish a lightweight root manifest.
+
+    Single-process callers keep their historical filename.  In distributed
+    prediction each rank writes only to its own file/directory, avoiding the
+    append and HDF5 collisions caused by a shared path.  The manifest is an
+    intentionally simple discovery record; dataset-index information remains
+    in the persisted ``index`` auxiliary field when a datamodule provides it.
+    """
+    if not torch.distributed.is_available() or not torch.distributed.is_initialized():
+        return path
+    world_size = torch.distributed.get_world_size()
+    if world_size == 1:
+        return path
+    rank = torch.distributed.get_rank()
+    root, extension = os.path.splitext(path)
+    sharded = f"{root}.rank-{rank}{extension}"
+    if rank == 0:
+        manifest_path = f"{root}.manifest.json"
+        with open(manifest_path, "w", encoding="utf-8") as manifest:
+            json.dump(
+                {
+                    "version": 1,
+                    "world_size": world_size,
+                    "shards": [
+                        os.path.basename(f"{root}.rank-{worker}{extension}")
+                        for worker in range(world_size)
+                    ],
+                },
+                manifest,
+            )
+    return sharded
+
+
+def _writer_array(value: Tensor | object) -> np.ndarray:
+    """Convert one writer value without deleting a one-item batch axis."""
+    array = (
+        value.detach().cpu().numpy() if isinstance(value, Tensor) else np.array(value)
+    )
+    if array.ndim >= 2 and array.shape[-1] == 1:
+        return np.squeeze(array, axis=-1)
+    if array.ndim == 0:
+        return array.reshape(1)
+    return array
+
+
 def save_image_predictions(outputs: STEP_OUTPUT, batch_idx: int, save_dir: str) -> None:
     """Save segmentation predictions to separate hdf5 files.
+
+    .. versionchanged:: 0.4.0
+
+       Distributed runs write rank-sharded dense predictions and a root
+       manifest instead of allowing multiple ranks to overwrite one file.
 
     Args:
         outputs: metrics and values to be saved
@@ -302,6 +401,8 @@ def save_image_predictions(outputs: STEP_OUTPUT, batch_idx: int, save_dir: str) 
     # Lightning types the hook argument as STEP_OUTPUT; the UQ methods always
     # return a dict from test_step, so narrow once here rather than at every hook.
     assert isinstance(outputs, dict)
+    save_dir = _distributed_path(save_dir)
+    os.makedirs(save_dir, exist_ok=True)
     for sample_idx in range(outputs["pred"].shape[0]):
         with h5py.File(
             f"{save_dir}/batch_{batch_idx}_sample_{sample_idx}.hdf5", "w"
@@ -320,6 +421,11 @@ def save_image_predictions(outputs: STEP_OUTPUT, batch_idx: int, save_dir: str) 
 def save_regression_predictions(outputs: STEP_OUTPUT, path: str) -> None:
     """Save regression predictions to csv file.
 
+    .. versionchanged:: 0.4.0
+
+       The writer copies the output mapping and preserves one-item batch axes;
+       it no longer consumes ``samples`` from the caller's result dictionary.
+
     Args:
         outputs: metrics and values to be saved
             - pred: predictions of shape [batch_size]
@@ -333,21 +439,28 @@ def save_regression_predictions(outputs: STEP_OUTPUT, path: str) -> None:
     # Lightning types the hook argument as STEP_OUTPUT; the UQ methods always
     # return a dict from test_step, so narrow once here rather than at every hook.
     assert isinstance(outputs, dict)
+    # Writers are observers: callers often use the same output object for
+    # logging/callbacks after this hook, so never pop or otherwise mutate it.
+    copied_outputs = dict(outputs)
+    path = _distributed_path(path)
+    parent_dir = os.path.dirname(path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
     cpu_outputs = {}
-    if "samples" in outputs:
-        samples = outputs.pop("samples")
+    if "samples" in copied_outputs:
+        samples = copied_outputs.pop("samples")
         for i in range(samples.shape[-1]):
-            sample = samples[..., i].squeeze(-1).cpu().numpy()
+            sample = _writer_array(samples[..., i])
             # mve prediction
             if sample.ndim == 2 and sample.shape[-1] == 2:
                 sample = sample[:, 0]
             cpu_outputs[f"sample_{i}"] = sample
 
-    for key, val in outputs.items():
+    for key, val in copied_outputs.items():
         if isinstance(val, Tensor):
-            cpu_outputs[key] = val.squeeze(-1).cpu().numpy()
+            cpu_outputs[key] = _writer_array(val)
         else:
-            cpu_outputs[key] = np.array(val)
+            cpu_outputs[key] = _writer_array(val)
 
     df = pd.DataFrame.from_dict(cpu_outputs)
 
@@ -359,9 +472,17 @@ def save_regression_predictions(outputs: STEP_OUTPUT, path: str) -> None:
 
 
 def save_classification_predictions(
-    outputs: STEP_OUTPUT, path: str, task: str = "multiclass"
+    outputs: STEP_OUTPUT,
+    path: str,
+    task: str = "multiclass",
+    binary_encoding: str = "two_logit",
 ) -> None:
     """Save classification predictions to csv file.
+
+    .. versionchanged:: 0.4.0
+
+       The writer is non-mutating, handles a one-logit binary task explicitly,
+       and rank-shards distributed output to avoid append collisions.
 
     For the "multilabel" task the labels are not mutually exclusive, so instead
     of a single ``pred`` column there is one ``pred_i`` column per label,
@@ -376,35 +497,42 @@ def save_classification_predictions(
             - pred_uct: predictive uncertainty of shape [batch_size]
         path: path where csv should be saved
         task: one of "binary", "multiclass" or "multilabel"
+        binary_encoding: binary probability encoding for the one-logit CSV
+            thresholding case.
     """
     # Lightning types the hook argument as STEP_OUTPUT; the UQ methods always
     # return a dict from test_step, so narrow once here rather than at every hook.
     assert isinstance(outputs, dict)
-    if "samples" in outputs:
-        _ = outputs.pop("samples")
-    if "logits" in outputs:
-        _ = outputs.pop("logits")
+    copied_outputs = dict(outputs)
+    path = _distributed_path(path)
+    parent_dir = os.path.dirname(path)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+    if "samples" in copied_outputs:
+        _ = copied_outputs.pop("samples")
+    if "logits" in copied_outputs:
+        _ = copied_outputs.pop("logits")
 
-    pred_set_true = "pred_set" in outputs
+    pred_set_true = "pred_set" in copied_outputs
 
     if pred_set_true:
         pred_set = [
-            str(tensor.cpu().numpy().tolist()) for tensor in outputs.pop("pred_set")
+            str(tensor.cpu().numpy().tolist())
+            for tensor in copied_outputs.pop("pred_set")
         ]
         df_pred_set = pd.DataFrame(pred_set, columns=["pred_set"])
 
     # save inidividual predictions as class probs
-    class_probs = outputs.pop("pred")
+    class_probs = copied_outputs.pop("pred")
+    if task == "binary" and binary_encoding == "one_logit" and class_probs.ndim == 1:
+        class_probs = class_probs.unsqueeze(1)
 
     for i in range(class_probs.shape[1]):
-        outputs[f"class_prob_{i}"] = class_probs[:, i]
+        copied_outputs[f"class_prob_{i}"] = class_probs[:, i]
 
     cpu_outputs = {}
-    for key, val in outputs.items():
-        if isinstance(val, Tensor):
-            val = val.squeeze(-1).cpu().numpy()
-        else:
-            val = np.array(val)
+    for key, val in copied_outputs.items():
+        val = _writer_array(val)
         # per-label targets and the like need one column each
         if val.ndim == 2:
             for i in range(val.shape[1]):
@@ -417,6 +545,9 @@ def save_classification_predictions(
         df_pred = pd.DataFrame(
             preds, columns=[f"pred_{i}" for i in range(preds.shape[1])]
         )
+    elif task == "binary" and binary_encoding == "one_logit":
+        pred_class = (class_probs[:, 0] > 0.5).int().cpu().numpy()
+        df_pred = pd.DataFrame(pred_class, columns=["pred"])
     else:
         pred_class = torch.argmax(class_probs, dim=1).cpu().numpy()
         df_pred = pd.DataFrame(pred_class, columns=["pred"])

--- a/tests/configs/classification/deterministic_canonical.yaml
+++ b/tests/configs/classification/deterministic_canonical.yaml
@@ -1,0 +1,16 @@
+model:
+  class_path: lightning_uq_box.uq_methods.Deterministic
+  init_args:
+    model:
+      class_path: lightning_uq_box.models.MLP
+      init_args:
+        n_outputs: 2
+        n_hidden: [50]
+        activation_fn:
+          class_path: torch.nn.ReLU
+    loss_fn:
+      class_path: torch.nn.CrossEntropyLoss
+    task:
+      class_path: lightning_uq_box.uq_methods.ClassificationTask
+      init_args:
+        mode: multiclass

--- a/tests/configs/classification/mc_dropout_canonical.yaml
+++ b/tests/configs/classification/mc_dropout_canonical.yaml
@@ -1,0 +1,18 @@
+model:
+  class_path: lightning_uq_box.uq_methods.MCDropout
+  init_args:
+    model:
+      class_path: lightning_uq_box.models.MLP
+      init_args:
+        n_outputs: 2
+        n_hidden: [50]
+        dropout_p: 0.1
+        activation_fn:
+          class_path: torch.nn.ReLU
+    num_mc_samples: 2
+    loss_fn:
+      class_path: torch.nn.CrossEntropyLoss
+    task:
+      class_path: lightning_uq_box.uq_methods.ClassificationTask
+      init_args:
+        mode: multiclass

--- a/tests/configs/image_segmentation/deterministic_canonical.yaml
+++ b/tests/configs/image_segmentation/deterministic_canonical.yaml
@@ -1,0 +1,22 @@
+uq_method:
+  _target_: lightning_uq_box.uq_methods.Deterministic
+  model:
+    _target_: segmentation_models_pytorch.Unet
+    encoder_name: resnet18
+    encoder_weights: null
+    classes: 4
+    in_channels: 3
+    encoder_depth: 2
+    decoder_channels: [16, 8]
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 0.003
+  lr_scheduler:
+    _target_: torch.optim.lr_scheduler.ConstantLR
+    _partial_: true
+  loss_fn:
+    _target_: torch.nn.CrossEntropyLoss
+  task:
+    _target_: lightning_uq_box.uq_methods.SegmentationTask
+    mode: multiclass

--- a/tests/configs/image_segmentation/mc_dropout_canonical.yaml
+++ b/tests/configs/image_segmentation/mc_dropout_canonical.yaml
@@ -1,0 +1,23 @@
+uq_method:
+  _target_: lightning_uq_box.uq_methods.MCDropout
+  model:
+    _target_: segmentation_models_pytorch.Unet
+    encoder_name: resnet18
+    encoder_weights: null
+    classes: 4
+    in_channels: 3
+    encoder_depth: 2
+    decoder_channels: [16, 8]
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 0.003
+  lr_scheduler:
+    _target_: torch.optim.lr_scheduler.ConstantLR
+    _partial_: true
+  num_mc_samples: 2
+  loss_fn:
+    _target_: torch.nn.CrossEntropyLoss
+  task:
+    _target_: lightning_uq_box.uq_methods.SegmentationTask
+    mode: multiclass

--- a/tests/configs/pixelwise_regression/deterministic_canonical.yaml
+++ b/tests/configs/pixelwise_regression/deterministic_canonical.yaml
@@ -1,0 +1,21 @@
+uq_method:
+  _target_: lightning_uq_box.uq_methods.Deterministic
+  model:
+    _target_: segmentation_models_pytorch.Unet
+    encoder_name: resnet18
+    encoder_weights: null
+    classes: 1
+    in_channels: 3
+    encoder_depth: 2
+    decoder_channels: [16, 8]
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 0.003
+  lr_scheduler:
+    _target_: torch.optim.lr_scheduler.ConstantLR
+    _partial_: true
+  loss_fn:
+    _target_: torch.nn.MSELoss
+  task:
+    _target_: lightning_uq_box.uq_methods.PixelRegressionTask

--- a/tests/configs/pixelwise_regression/mc_dropout_canonical.yaml
+++ b/tests/configs/pixelwise_regression/mc_dropout_canonical.yaml
@@ -1,0 +1,22 @@
+uq_method:
+  _target_: lightning_uq_box.uq_methods.MCDropout
+  model:
+    _target_: segmentation_models_pytorch.Unet
+    encoder_name: resnet18
+    encoder_weights: null
+    classes: 1
+    in_channels: 3
+    encoder_depth: 2
+    decoder_channels: [16, 8]
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 0.003
+  lr_scheduler:
+    _target_: torch.optim.lr_scheduler.ConstantLR
+    _partial_: true
+  num_mc_samples: 2
+  loss_fn:
+    _target_: torch.nn.MSELoss
+  task:
+    _target_: lightning_uq_box.uq_methods.PixelRegressionTask

--- a/tests/configs/regression/deterministic_canonical.yaml
+++ b/tests/configs/regression/deterministic_canonical.yaml
@@ -1,0 +1,17 @@
+model:
+  class_path: lightning_uq_box.uq_methods.Deterministic
+  init_args:
+    model:
+      class_path: lightning_uq_box.models.MLP
+      init_args:
+        n_outputs: 1
+        n_hidden: [50]
+        activation_fn:
+          class_path: torch.nn.ReLU
+    loss_fn:
+      class_path: torch.nn.MSELoss
+    task:
+      class_path: lightning_uq_box.uq_methods.RegressionTask
+      init_args: {}
+    lr_scheduler:
+      class_path: torch.optim.lr_scheduler.ConstantLR

--- a/tests/configs/regression/mc_dropout_canonical.yaml
+++ b/tests/configs/regression/mc_dropout_canonical.yaml
@@ -1,0 +1,17 @@
+model:
+  class_path: lightning_uq_box.uq_methods.MCDropout
+  init_args:
+    model:
+      class_path: lightning_uq_box.models.MLP
+      init_args:
+        n_outputs: 1
+        n_hidden: [50]
+        dropout_p: 0.1
+        activation_fn:
+          class_path: torch.nn.ReLU
+    num_mc_samples: 2
+    loss_fn:
+      class_path: torch.nn.MSELoss
+    task:
+      class_path: lightning_uq_box.uq_methods.RegressionTask
+      init_args: {}

--- a/tests/uq_methods/test_legacy_adapters.py
+++ b/tests/uq_methods/test_legacy_adapters.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""0.4 compatibility checks for migrated concrete task class adapters."""
+
+import importlib
+import inspect
+
+import pytest
+from torch import nn
+
+from lightning_uq_box.uq_methods import DeterministicRegression, MCDropoutRegression
+
+
+def test_deterministic_regression_adapter_warns_and_keeps_signature() -> None:
+    """The legacy deterministic name remains callable with its old arguments."""
+    parameters = tuple(inspect.signature(DeterministicRegression).parameters)
+    assert parameters == (
+        "model",
+        "loss_fn",
+        "freeze_backbone",
+        "optimizer",
+        "lr_scheduler",
+    )
+    with pytest.warns(DeprecationWarning, match="DeterministicRegression"):
+        module = DeterministicRegression(nn.Linear(2, 1), nn.MSELoss())
+    assert all(key.startswith("model.") for key in module.state_dict())
+
+
+def test_mc_dropout_adapter_warns_and_historical_module_imports() -> None:
+    """MC Dropout keeps both its local import path and state-key topology."""
+    module_path = importlib.import_module("lightning_uq_box.uq_methods.mc_dropout")
+    assert module_path.MCDropoutRegression is MCDropoutRegression
+    with pytest.warns(DeprecationWarning, match="MCDropoutRegression"):
+        module = MCDropoutRegression(
+            nn.Sequential(nn.Linear(2, 2), nn.Dropout(), nn.Linear(2, 1)),
+            num_mc_samples=2,
+            loss_fn=nn.MSELoss(),
+        )
+    assert all(key.startswith("model.") for key in module.state_dict())

--- a/tests/uq_methods/test_method_specs.py
+++ b/tests/uq_methods/test_method_specs.py
@@ -4,13 +4,60 @@
 """Tests for the checked-in canonical capability inventory."""
 
 from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import torch
 
 from lightning_uq_box.uq_methods import (
     ClassificationTask,
+    PixelRegressionTask,
+    RegressionTask,
     get_method_spec,
     iter_method_specs,
 )
-from lightning_uq_box.uq_methods.contracts import validate_method_specs
+from lightning_uq_box.uq_methods.contracts import (
+    MethodSpec,
+    OutputField,
+    OutputSchema,
+    TaskCapability,
+    validate_method_specs,
+)
+
+
+def _schema(**overrides) -> OutputSchema:
+    """Build the smallest valid regression output schema."""
+    values: dict[str, Any] = {
+        "task_type": RegressionTask,
+        "raw_axes": ("batch", "target"),
+        "metric_input": "raw_prediction",
+        "fields": (OutputField(name="pred", axes=("batch", "target")),),
+    }
+    values.update(overrides)
+    return OutputSchema(**values)
+
+
+def _capability(**overrides) -> TaskCapability:
+    """Build the smallest valid regression capability."""
+    values: dict[str, Any] = {
+        "task_type": RegressionTask,
+        "schema": _schema(),
+        "smoke_factory_id": "regression",
+        "test_id": "tests/uq_methods/test_method_specs.py",
+        "config_path": "tests/configs/regression/deterministic_canonical.yaml",
+        "writer": "csv",
+        "checkpoint_fixture_id": "constructed_module_strict",
+    }
+    values.update(overrides)
+    return TaskCapability(**values)
+
+
+def _factory():
+    """Supply a valid minimal factory for MethodSpec validation tests."""
+    return torch.nn.Linear(1, 1), {
+        "input": torch.zeros(1, 1),
+        "target": torch.zeros(1, 1),
+    }
 
 
 def test_method_specs_are_valid_and_discoverable() -> None:
@@ -26,6 +73,8 @@ def test_method_specs_are_valid_and_discoverable() -> None:
             model, batch = spec.smoke_factories[capability.smoke_factory_id]()
             assert model is not None
             assert {"input", "target"}.issubset(batch)
+    with pytest.raises(KeyError, match="Unknown canonical method"):
+        get_method_spec("NotAMethod")
 
 
 def test_binary_encodings_have_distinct_capabilities() -> None:
@@ -43,3 +92,114 @@ def test_binary_encodings_have_distinct_capabilities() -> None:
         ).schema.binary_encoding
         == "two_logit"
     )
+
+
+def test_output_schema_rejects_duplicate_field_names() -> None:
+    """A schema cannot give two public fields the same contract name."""
+    with pytest.raises(ValueError, match="unique"):
+        _schema(
+            fields=(
+                OutputField(name="pred", axes=("batch",)),
+                OutputField(name="pred", axes=("batch",)),
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"fields": (OutputField(name="logits", axes=("batch",)),)},
+        {"metric_input": ""},
+        {"modes": frozenset({"binary"})},
+        {
+            "task_type": ClassificationTask,
+            "modes": frozenset({"multiclass"}),
+            "binary_encoding": "one_logit",
+        },
+        {"uncertainty_fields": frozenset({"pred_uct"})},
+    ],
+)
+def test_output_schema_rejects_invalid_declarations(overrides) -> None:
+    """Schemas reject invalid task/mode and public-field combinations."""
+    with pytest.raises(ValueError):
+        _schema(**overrides)
+
+
+def test_output_schema_acceptance_and_payload_errors() -> None:
+    """Schemas enforce exact task types and stable output ranks."""
+    schema = _schema(
+        fields=(
+            OutputField(name="pred", axes=("batch", "target")),
+            OutputField(name="optional", axes=("batch",), required=False),
+        )
+    )
+    assert schema.public_keys == frozenset({"pred", "optional"})
+    assert schema.accepts(RegressionTask())
+    assert not schema.accepts(PixelRegressionTask())
+    with pytest.raises(ValueError, match="undeclared"):
+        schema.validate_payload({"pred": torch.zeros(1, 1), "unknown": torch.zeros(1)})
+    with pytest.raises(ValueError, match="missing"):
+        schema.validate_payload({})
+    with pytest.raises(TypeError, match="Tensor"):
+        schema.validate_payload(cast(dict[str, torch.Tensor], {"pred": "not-a-tensor"}))
+    with pytest.raises(ValueError, match="rank"):
+        schema.validate_payload({"pred": torch.zeros(1)})
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"task_type": ClassificationTask},
+        {"modes": frozenset({"binary"})},
+        {"stages": frozenset()},
+        {"smoke_factory_id": ""},
+        {"test_id": ""},
+        {"config_path": ""},
+        {"writer": "parquet"},
+        {"checkpoint_fixture_id": ""},
+    ],
+)
+def test_task_capability_rejects_incomplete_contracts(overrides) -> None:
+    """Capabilities require one complete, matching vertical-slice contract."""
+    with pytest.raises(ValueError):
+        _capability(**overrides)
+
+
+def test_method_spec_and_registry_error_paths() -> None:
+    """The capability registry rejects incomplete and ambiguous inventories."""
+    capability = _capability()
+    with pytest.raises(ValueError):
+        MethodSpec(name="", class_path="example.Method", capabilities=(capability,))
+    with pytest.raises(ValueError):
+        MethodSpec(name="Example", class_path="example.Method", capabilities=())
+    with pytest.raises(ValueError):
+        MethodSpec(
+            name="Example",
+            class_path="example.Method",
+            capabilities=(capability, capability),
+            smoke_factories={"regression": _factory},
+        )
+    with pytest.raises(ValueError):
+        MethodSpec(
+            name="Example", class_path="example.Method", capabilities=(capability,)
+        )
+
+    spec = MethodSpec(
+        name="Example",
+        class_path="example.Method",
+        capabilities=(capability,),
+        smoke_factories={"regression": _factory},
+    )
+    assert spec.capability_for(RegressionTask()).accepts(RegressionTask(), "test")
+    with pytest.raises(ValueError, match="does not support"):
+        spec.capability_for(ClassificationTask(mode="multiclass"), "predict")
+    with pytest.raises(ValueError, match="names must be unique"):
+        validate_method_specs((spec, spec))
+    duplicate_path = MethodSpec(
+        name="Other",
+        class_path="example.Method",
+        capabilities=(capability,),
+        smoke_factories={"regression": _factory},
+    )
+    with pytest.raises(ValueError, match="class paths must be unique"):
+        validate_method_specs((spec, duplicate_path))

--- a/tests/uq_methods/test_method_specs.py
+++ b/tests/uq_methods/test_method_specs.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Tests for the checked-in canonical capability inventory."""
+
+from pathlib import Path
+
+from lightning_uq_box.uq_methods import (
+    ClassificationTask,
+    get_method_spec,
+    iter_method_specs,
+)
+from lightning_uq_box.uq_methods.contracts import validate_method_specs
+
+
+def test_method_specs_are_valid_and_discoverable() -> None:
+    """The registry is validated at import and supports public discovery."""
+    specs = tuple(iter_method_specs())
+    validate_method_specs(specs)
+    assert get_method_spec("Deterministic") in specs
+    assert get_method_spec("MCDropout") in specs
+    for spec in specs:
+        for capability in spec.capabilities:
+            assert Path(capability.config_path).is_file()
+            assert Path(capability.test_id).is_file()
+            model, batch = spec.smoke_factories[capability.smoke_factory_id]()
+            assert model is not None
+            assert {"input", "target"}.issubset(batch)
+
+
+def test_binary_encodings_have_distinct_capabilities() -> None:
+    """Binary BCE and CE are declared rather than inferred from output shape."""
+    spec = get_method_spec("Deterministic")
+    assert (
+        spec.capability_for(
+            ClassificationTask(mode="binary", binary_encoding="one_logit")
+        ).schema.binary_encoding
+        == "one_logit"
+    )
+    assert (
+        spec.capability_for(
+            ClassificationTask(mode="binary", binary_encoding="two_logit")
+        ).schema.binary_encoding
+        == "two_logit"
+    )

--- a/tests/uq_methods/test_prediction_writers.py
+++ b/tests/uq_methods/test_prediction_writers.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Regression tests for non-mutating prediction persistence."""
+
+from pathlib import Path
+
+import torch
+
+from lightning_uq_box.uq_methods.utils import (
+    save_classification_predictions,
+    save_regression_predictions,
+)
+
+
+def test_regression_writer_does_not_mutate_samples(tmp_path: Path) -> None:
+    """A writer observes a result dictionary instead of popping its samples."""
+    outputs = {
+        "pred": torch.zeros(1, 1),
+        "samples": torch.zeros(1, 1, 2),
+        "target": torch.zeros(1, 1),
+    }
+    save_regression_predictions(outputs, str(tmp_path / "preds.csv"))
+    assert "samples" in outputs
+
+
+def test_binary_writer_preserves_a_one_item_batch(tmp_path: Path) -> None:
+    """One-logit binary outputs persist one CSV row rather than scalars."""
+    outputs = {
+        "pred": torch.tensor([[0.8]]),
+        "pred_uct": torch.tensor([0.5]),
+        "logits": torch.tensor([[1.4]]),
+        "target": torch.tensor([1.0]),
+    }
+    save_classification_predictions(
+        outputs, str(tmp_path / "preds.csv"), task="binary", binary_encoding="one_logit"
+    )
+    assert "pred" in outputs
+    assert (tmp_path / "preds.csv").read_text(encoding="utf-8").count("\n") == 2

--- a/tests/uq_methods/test_public_api_inventory.py
+++ b/tests/uq_methods/test_public_api_inventory.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Public-surface inventory guards for the method/task migration."""
+
+import importlib
+
+import lightning_uq_box.uq_methods as uq_methods
+
+
+def test_all_exported_symbols_are_bound() -> None:
+    """The package export list cannot advertise a missing public symbol."""
+    missing = [name for name in uq_methods.__all__ if not hasattr(uq_methods, name)]
+    assert not missing
+
+
+def test_canonical_and_historical_module_imports_remain_bound() -> None:
+    """Canonical seams do not remove historical method submodule imports."""
+    modules = (
+        "base",
+        "mc_dropout",
+        "swag",
+        "sgld",
+        "masked_ensemble",
+        "bnn_vi_elbo",
+        "deep_ensemble",
+        "deep_kernel_learning",
+        "deterministic_uncertainty_estimation",
+        "mean_variance_estimation",
+        "deep_evidential_regression",
+        "quantile_regression",
+        "mixture_density",
+        "density_uncertainty",
+        "tasks",
+        "contracts",
+        "method_specs",
+        "task_runtime",
+    )
+    for module in modules:
+        imported = importlib.import_module(f"lightning_uq_box.uq_methods.{module}")
+        assert imported is not None

--- a/tests/uq_methods/test_task_method_base.py
+++ b/tests/uq_methods/test_task_method_base.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Contract tests for canonical task-aware base methods."""
+
+import lightning
+import pytest
+import torch
+from lightning import Trainer
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+
+from lightning_uq_box.uq_methods import (
+    NLL,
+    ClassificationTask,
+    Deterministic,
+    MCDropout,
+    PixelRegressionTask,
+    RegressionTask,
+    SegmentationTask,
+)
+
+
+class SingleBatchDataset(Dataset[dict[str, torch.Tensor]]):
+    """A one-item dataset that returns an already collated tutorial batch."""
+
+    def __init__(self, batch: dict[str, torch.Tensor]) -> None:
+        """Store one complete batch."""
+        self.batch = batch
+
+    def __len__(self) -> int:
+        """Return the number of complete batches."""
+        return 1
+
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
+        """Return the stored batch."""
+        assert index == 0
+        return self.batch
+
+
+def test_canonical_runtime_has_no_state_dict_entries() -> None:
+    """Metrics/runtime remain run state rather than checkpoint model state."""
+    module = Deterministic(nn.Linear(2, 1), nn.MSELoss(), task=RegressionTask())
+    assert not module.task_runtime.state_dict()
+    assert not any(key.startswith("task_runtime.") for key in module.state_dict())
+
+
+def test_equivalent_canonical_module_loads_strictly() -> None:
+    """Task runtime registration does not add incompatible checkpoint keys."""
+    source = Deterministic(nn.Linear(2, 1), nn.MSELoss(), task=RegressionTask())
+    target = Deterministic(nn.Linear(2, 1), nn.MSELoss(), task=RegressionTask())
+    incompatible = target.load_state_dict(source.state_dict(), strict=True)
+    assert not incompatible.missing_keys
+    assert not incompatible.unexpected_keys
+
+
+def test_direct_checkpoint_load_is_strict_when_dependencies_are_supplied(
+    tmp_path,
+) -> None:
+    """The canonical checkpoint boundary documents caller-supplied modules."""
+    source = Deterministic(nn.Linear(2, 1), nn.MSELoss(), task=RegressionTask())
+    checkpoint_path = tmp_path / "canonical.ckpt"
+    torch.save(
+        {
+            "state_dict": source.state_dict(),
+            "hyper_parameters": dict(source.hparams),
+            "pytorch-lightning_version": lightning.__version__,
+        },
+        checkpoint_path,
+    )
+    restored = Deterministic.load_from_checkpoint(
+        checkpoint_path, model=nn.Linear(2, 1), loss_fn=nn.MSELoss(), strict=True
+    )
+    assert restored.task == RegressionTask()
+
+
+def test_binary_one_logit_keeps_batch_dimension_for_one_example() -> None:
+    """A single-item batch is a batch in the public prediction contract."""
+    module = Deterministic(
+        nn.Linear(2, 1),
+        nn.BCEWithLogitsLoss(),
+        task=ClassificationTask(mode="binary", binary_encoding="one_logit"),
+    )
+    output = module.predict_step(torch.zeros(1, 2))
+    assert output["pred"].shape == (1, 1)
+    assert output["pred_uct"].shape == (1,)
+    assert output["logits"].shape == (1, 1)
+
+
+def test_canonical_mc_dropout_keeps_its_sample_axis_method_owned() -> None:
+    """MC Dropout exposes sampled logits while the runtime stays stateless."""
+    model = nn.Sequential(nn.Linear(2, 4), nn.Dropout(), nn.Linear(4, 1))
+    module = MCDropout(
+        model,
+        num_mc_samples=3,
+        loss_fn=nn.BCEWithLogitsLoss(),
+        task=ClassificationTask(mode="binary", binary_encoding="one_logit"),
+    )
+    output = module.predict_step(torch.zeros(1, 2))
+    assert output["pred"].shape == (1, 1)
+    assert output["logits"].shape == (1, 1, 3)
+    assert not module.task_runtime.state_dict()
+
+
+def test_canonical_tutorial_paths_train_and_test(tmp_path) -> None:
+    """The deterministic and Gaussian MC Dropout tutorial APIs run end to end."""
+    classification = Deterministic(
+        nn.Sequential(nn.Linear(2, 4), nn.ReLU(), nn.Linear(4, 2)),
+        nn.CrossEntropyLoss(),
+        task=ClassificationTask(mode="multiclass"),
+    )
+    classification_batch = {
+        "input": torch.zeros(2, 2),
+        "target": torch.zeros(2, dtype=torch.long),
+    }
+    trainer = Trainer(
+        fast_dev_run=True,
+        default_root_dir=tmp_path / "classification",
+        logger=False,
+        enable_model_summary=False,
+    )
+    classification_loader = DataLoader(
+        SingleBatchDataset(classification_batch), batch_size=None
+    )
+    trainer.fit(classification, train_dataloaders=classification_loader)
+    trainer.test(classification, dataloaders=classification_loader)
+
+    regression = MCDropout(
+        nn.Sequential(nn.Linear(1, 4), nn.Dropout(), nn.Linear(4, 2)),
+        num_mc_samples=2,
+        loss_fn=NLL(),
+        task=RegressionTask(),
+        prediction_kind="gaussian",
+    )
+    regression_batch = {"input": torch.zeros(2, 1), "target": torch.zeros(2, 1)}
+    trainer = Trainer(
+        fast_dev_run=True,
+        default_root_dir=tmp_path / "regression",
+        logger=False,
+        enable_model_summary=False,
+    )
+    regression_loader = DataLoader(
+        SingleBatchDataset(regression_batch), batch_size=None
+    )
+    trainer.fit(regression, train_dataloaders=regression_loader)
+    trainer.test(regression, dataloaders=regression_loader)
+
+
+@pytest.mark.parametrize(
+    ("task", "model", "loss", "input_tensor", "pred_shape"),
+    [
+        (RegressionTask(), nn.Linear(2, 1), nn.MSELoss(), torch.zeros(2, 2), (2, 1)),
+        (
+            ClassificationTask(mode="multiclass"),
+            nn.Linear(2, 3),
+            nn.CrossEntropyLoss(),
+            torch.zeros(2, 2),
+            (2, 3),
+        ),
+        (
+            SegmentationTask(mode="multiclass"),
+            nn.Conv2d(1, 3, kernel_size=1),
+            nn.CrossEntropyLoss(),
+            torch.zeros(2, 1, 4, 4),
+            (2, 3, 4, 4),
+        ),
+        (
+            PixelRegressionTask(),
+            nn.Conv2d(1, 1, kernel_size=1),
+            nn.MSELoss(),
+            torch.zeros(2, 1, 4, 4),
+            (2, 1, 4, 4),
+        ),
+    ],
+)
+def test_declared_deterministic_capabilities_have_contract_payloads(
+    task, model, loss, input_tensor, pred_shape
+) -> None:
+    """Each task family returned by the canonical pilot is explicitly shaped."""
+    module = Deterministic(model, loss, task=task)
+    payload = module.predict_step(input_tensor)
+    assert payload["pred"].shape == pred_shape
+    module.output_schema.validate_payload(payload)

--- a/tests/uq_methods/test_task_method_base.py
+++ b/tests/uq_methods/test_task_method_base.py
@@ -3,6 +3,9 @@
 
 """Contract tests for canonical task-aware base methods."""
 
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
 import lightning
 import pytest
 import torch
@@ -10,6 +13,7 @@ from lightning import Trainer
 from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
+import lightning_uq_box.uq_methods.task_runtime as task_runtime_module
 from lightning_uq_box.uq_methods import (
     NLL,
     ClassificationTask,
@@ -18,7 +22,17 @@ from lightning_uq_box.uq_methods import (
     PixelRegressionTask,
     RegressionTask,
     SegmentationTask,
+    TaskMethodBase,
+    TaskSpec,
 )
+from lightning_uq_box.uq_methods.method_specs import (
+    BINARY_ONE_LOGIT_SCHEMA,
+    CLASSIFICATION_SCHEMA,
+    PIXEL_REGRESSION_SCHEMA,
+    REGRESSION_SCHEMA,
+    SEGMENTATION_SCHEMA,
+)
+from lightning_uq_box.uq_methods.task_runtime import TaskRuntime
 
 
 class SingleBatchDataset(Dataset[dict[str, torch.Tensor]]):
@@ -36,6 +50,27 @@ class SingleBatchDataset(Dataset[dict[str, torch.Tensor]]):
         """Return the stored batch."""
         assert index == 0
         return self.batch
+
+
+@dataclass(frozen=True, kw_only=True)
+class UnsupportedTask(TaskSpec):
+    """A task value intentionally absent from the runtime dispatch table."""
+
+    class_path: ClassVar[str] = "tests.UnsupportedTask"
+
+
+class TupleOutputModel(nn.Module):
+    """Model fixture whose output intentionally violates canonical contracts."""
+
+    def __init__(self) -> None:
+        """Build a model with both a dropout module and a linear output layer."""
+        super().__init__()
+        self.dropout = nn.Dropout()
+        self.output = nn.Linear(2, 1)
+
+    def forward(self, X: torch.Tensor) -> tuple[torch.Tensor]:
+        """Return a non-Tensor output to exercise public contract errors."""
+        return (self.output(self.dropout(X)),)
 
 
 def test_canonical_runtime_has_no_state_dict_entries() -> None:
@@ -181,3 +216,301 @@ def test_declared_deterministic_capabilities_have_contract_payloads(
     payload = module.predict_step(input_tensor)
     assert payload["pred"].shape == pred_shape
     module.output_schema.validate_payload(payload)
+
+
+def test_task_runtime_properties_target_rules_and_metric_lifecycle() -> None:
+    """The runtime owns exact target semantics and run-only metric state."""
+    regression = TaskRuntime(RegressionTask(), REGRESSION_SCHEMA, num_outputs=1)
+    assert regression.train_metrics is not None
+    assert regression.val_metrics is not None
+    assert regression.test_metrics is not None
+    prediction = torch.zeros(1, 1)
+    target = torch.ones(1, 1)
+    regression.update_metrics("train", prediction, target)
+    assert regression.compute_and_reset("train")
+
+    multiclass = TaskRuntime(
+        ClassificationTask(mode="multiclass"), CLASSIFICATION_SCHEMA, num_outputs=2
+    )
+    class_target = torch.tensor([[1], [0]])
+    assert multiclass.normalize_target(class_target).shape == (2,)
+    assert multiclass.target_for_loss(class_target, torch.zeros(2, 2)).shape == (2,)
+
+    binary = TaskRuntime(
+        ClassificationTask(mode="binary", binary_encoding="one_logit"),
+        BINARY_ONE_LOGIT_SCHEMA,
+        num_outputs=1,
+    )
+    binary_target = torch.tensor([[1.0], [0.0]])
+    assert binary.normalize_target(binary_target).shape == (2,)
+    assert binary.target_for_loss(
+        torch.tensor([1.0, 0.0]), torch.zeros(2, 1)
+    ).shape == (2, 1)
+
+
+def test_task_runtime_rejects_unknown_task_types() -> None:
+    """A task requires an explicit metrics implementation rather than fallback."""
+    schema = REGRESSION_SCHEMA.__class__(
+        task_type=UnsupportedTask,
+        raw_axes=("batch", "target"),
+        metric_input="raw_prediction",
+        fields=REGRESSION_SCHEMA.fields,
+    )
+    with pytest.raises(TypeError, match="Unsupported task runtime"):
+        TaskRuntime(UnsupportedTask(), schema, num_outputs=1)
+
+
+def test_task_runtime_copies_results_and_creates_dense_directory(tmp_path) -> None:
+    """Runtime results preserve tensor ownership and dense paths are explicit."""
+    runtime = TaskRuntime(RegressionTask(), REGRESSION_SCHEMA, num_outputs=1)
+    payload = {"pred": torch.ones(1, 1)}
+    batch: dict[str, Any] = {
+        "input": torch.zeros(1, 1),
+        "target": torch.zeros(1, 1),
+        "index": torch.tensor([4]),
+        "metadata": "keep-me",
+    }
+    result = runtime.test_result(payload, batch, input_key="input", target_key="target")
+    assert result["pred"].data_ptr() != payload["pred"].data_ptr()
+    assert result["index"].data_ptr() != batch["index"].data_ptr()
+    assert result["metadata"] == "keep-me"
+    with pytest.raises(TypeError, match="must be a Tensor"):
+        runtime.test_result(
+            payload,
+            {"input": torch.zeros(1, 1), "target": "not-a-tensor"},
+            input_key="input",
+            target_key="target",
+        )
+    assert runtime.on_test_start(str(tmp_path), save_predictions=True) is None
+
+    dense = TaskRuntime(
+        SegmentationTask(mode="multiclass"), SEGMENTATION_SCHEMA, num_outputs=2
+    )
+    assert dense.on_test_start(str(tmp_path), save_predictions=False) is None
+    pred_dir = dense.on_test_start(str(tmp_path), save_predictions=True)
+    assert pred_dir is not None
+    assert (tmp_path / "preds").is_dir()
+
+
+def test_task_runtime_writer_dispatch_is_non_mutating(tmp_path, monkeypatch) -> None:
+    """Each task family dispatches its writer with a copied result dictionary."""
+    calls: list[tuple[str, dict[str, Any], tuple[Any, ...], dict[str, Any]]] = []
+
+    def record(name: str):
+        def writer(outputs, *args, **kwargs) -> None:
+            outputs["pred"].zero_()
+            calls.append((name, outputs, args, kwargs))
+
+        return writer
+
+    monkeypatch.setattr(
+        task_runtime_module, "save_regression_predictions", record("csv")
+    )
+    monkeypatch.setattr(
+        task_runtime_module, "save_classification_predictions", record("class")
+    )
+    monkeypatch.setattr(task_runtime_module, "save_image_predictions", record("image"))
+    outputs: dict[str, Any] = {"pred": torch.ones(1, 1), "target": torch.zeros(1, 1)}
+
+    regression = TaskRuntime(RegressionTask(), REGRESSION_SCHEMA, num_outputs=1)
+    regression.write_test_result(
+        outputs,
+        root_dir=str(tmp_path),
+        batch_idx=0,
+        save_predictions=False,
+        prediction_dir=None,
+    )
+    classification = TaskRuntime(
+        ClassificationTask(mode="binary", binary_encoding="one_logit"),
+        BINARY_ONE_LOGIT_SCHEMA,
+        num_outputs=1,
+    )
+    classification.write_test_result(
+        outputs,
+        root_dir=str(tmp_path),
+        batch_idx=1,
+        save_predictions=False,
+        prediction_dir=None,
+    )
+    pixel = TaskRuntime(PixelRegressionTask(), PIXEL_REGRESSION_SCHEMA, num_outputs=1)
+    pixel.write_test_result(
+        outputs,
+        root_dir=str(tmp_path),
+        batch_idx=2,
+        save_predictions=False,
+        prediction_dir=None,
+    )
+    pixel.write_test_result(
+        outputs,
+        root_dir=str(tmp_path),
+        batch_idx=3,
+        save_predictions=True,
+        prediction_dir=str(tmp_path / "preds"),
+    )
+    pixel.write_test_result(
+        None,  # type: ignore[arg-type]
+        root_dir=str(tmp_path),
+        batch_idx=4,
+        save_predictions=True,
+        prediction_dir=str(tmp_path / "preds"),
+    )
+
+    assert [call[0] for call in calls] == ["csv", "class", "image"]
+    assert calls[1][3] == {"task": "binary", "binary_encoding": "one_logit"}
+    assert torch.equal(outputs["pred"], torch.ones(1, 1))
+
+
+def test_task_method_base_requires_spec_and_exposes_runtime_services() -> None:
+    """Canonical bases fail closed until their concrete method declares a spec."""
+    incomplete = TaskMethodBase()
+    with pytest.raises(TypeError, match="Task runtime"):
+        incomplete.save_task_hyperparameters({})
+    incomplete.model = nn.Linear(2, 1)
+    with pytest.raises(TypeError, match="MethodSpec"):
+        incomplete.initialize_task_runtime(None, default_task=RegressionTask())
+
+    module = Deterministic(nn.Linear(2, 1), nn.MSELoss(), task=RegressionTask())
+    assert module.supports_task(RegressionTask())
+    assert not module.supports_task(UnsupportedTask())
+    assert module.train_metrics is module.task_runtime.train_metrics
+    assert module.val_metrics is module.task_runtime.val_metrics
+    assert module.test_metrics is module.task_runtime.test_metrics
+
+
+def test_deterministic_validates_output_contract_and_lifecycle_paths(
+    monkeypatch,
+) -> None:
+    """Canonical deterministic methods test conversion, validation, and schedulers."""
+    invalid_binary = Deterministic(
+        nn.Linear(2, 2),
+        nn.BCEWithLogitsLoss(),
+        task=ClassificationTask(mode="binary", binary_encoding="one_logit"),
+    )
+    with pytest.raises(ValueError, match="one_logit"):
+        invalid_binary.predict_step(torch.zeros(1, 2))
+
+    multilabel = Deterministic(
+        nn.Linear(2, 3),
+        nn.BCEWithLogitsLoss(),
+        task=ClassificationTask(mode="multilabel"),
+    )
+    payload = multilabel.prediction_payload(torch.zeros(1, 3))
+    assert payload["pred"].shape == (1, 3)
+    assert payload["pred_uct"].shape == (1,)
+
+    model = nn.Sequential(nn.Linear(2, 2), nn.Linear(2, 1))
+    module = Deterministic(
+        model,
+        nn.MSELoss(),
+        task=RegressionTask(),
+        freeze_backbone=True,
+        lr_scheduler=lambda optimizer: torch.optim.lr_scheduler.StepLR(optimizer, 1),
+    )
+    assert not model[0].weight.requires_grad
+    assert model[1].weight.requires_grad
+    monkeypatch.setattr(module, "log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "log_dict", lambda *args, **kwargs: None)
+    batch = {"input": torch.zeros(1, 2), "target": torch.zeros(1, 1)}
+    assert module.validation_step(batch, 0).shape == ()
+    module.on_validation_epoch_end()
+    optimizer_config = module.configure_optimizers()
+    assert isinstance(optimizer_config, dict)
+    assert "lr_scheduler" in optimizer_config
+
+    tuple_module = Deterministic(
+        TupleOutputModel(), nn.MSELoss(), task=RegressionTask()
+    )
+    with pytest.raises(TypeError, match="Tensor model output"):
+        tuple_module.training_step(batch, 0)
+    with pytest.raises(TypeError, match="Tensor model output"):
+        tuple_module.predict_step(torch.zeros(1, 2))
+    with pytest.raises(TypeError, match="Tensor model output"):
+        tuple_module.test_step(batch, 0)
+
+
+def test_canonical_mc_dropout_covers_sampling_and_explicit_conversions(
+    monkeypatch,
+) -> None:
+    """MC Dropout keeps every sampling and distribution branch method-owned."""
+    model = nn.Sequential(
+        nn.Linear(2, 2), nn.BatchNorm1d(2), nn.Dropout(), nn.Linear(2, 1)
+    )
+    module = MCDropout(
+        model,
+        num_mc_samples=2,
+        loss_fn=nn.MSELoss(),
+        task=RegressionTask(),
+        dropout_layer_names=["2"],
+    )
+    module.eval()
+    module.activate_dropout()
+    assert not model[1].training
+    assert model[2].training
+    point_payload = module.prediction_payload(torch.zeros(2, 1, 1))
+    assert point_payload["pred"].shape == (1, 1)
+    assert point_payload["epistemic_uct"].shape == (1, 1)
+
+    with pytest.raises(ValueError, match="at least one"):
+        MCDropout(nn.Linear(2, 1), 0, nn.MSELoss())
+    with pytest.raises(ValueError, match="prediction_kind"):
+        MCDropout(nn.Linear(2, 1), 1, nn.MSELoss(), prediction_kind="unknown")
+    no_dropout = MCDropout(nn.Linear(2, 1), 1, nn.MSELoss())
+    with pytest.raises(UserWarning, match="No dropout"):
+        no_dropout.activate_dropout()
+    tuple_module = MCDropout(TupleOutputModel(), 1, nn.MSELoss())
+    with pytest.raises(TypeError, match="Tensor model outputs"):
+        tuple_module._samples(torch.zeros(1, 2))
+    tuple_burnin = MCDropout(
+        TupleOutputModel(), 1, nn.MSELoss(), task=RegressionTask(), burnin_epochs=1
+    )
+    monkeypatch.setattr(tuple_burnin, "log", lambda *args, **kwargs: None)
+    with pytest.raises(TypeError, match="Tensor model output"):
+        tuple_burnin.training_step(
+            {"input": torch.zeros(1, 2), "target": torch.zeros(1, 1)}, 0
+        )
+
+    gaussian = MCDropout(
+        nn.Sequential(nn.Linear(2, 2), nn.Dropout()),
+        2,
+        NLL(),
+        task=RegressionTask(),
+        prediction_kind="gaussian",
+    )
+    with pytest.raises(ValueError, match="two-channel"):
+        gaussian.prediction_payload(torch.zeros(2, 1, 1))
+    with pytest.raises(ValueError, match="two-channel"):
+        gaussian.metric_prediction(torch.zeros(1, 1), "test")
+    assert gaussian.metric_prediction(torch.zeros(1, 2), "test").shape == (1, 1)
+
+    for task, channels in [
+        (ClassificationTask(mode="multilabel"), 3),
+        (ClassificationTask(mode="binary", binary_encoding="one_logit"), 1),
+        (ClassificationTask(mode="multiclass"), 3),
+    ]:
+        classifier = MCDropout(
+            nn.Sequential(nn.Linear(2, channels), nn.Dropout()),
+            2,
+            nn.BCEWithLogitsLoss() if channels == 1 else nn.CrossEntropyLoss(),
+            task=task,
+        )
+        payload = classifier.prediction_payload(torch.zeros(2, 1, channels))
+        assert payload["pred"].shape == (1, channels)
+        assert payload["pred_uct"].shape == (1,)
+        assert payload["logits"].shape == (1, channels, 2)
+        assert classifier.metric_prediction(torch.zeros(1, channels), "test").shape in {
+            (1, channels),
+            (1,),
+        }
+
+    burnin = MCDropout(
+        nn.Sequential(nn.Linear(2, 1), nn.Dropout()),
+        2,
+        nn.L1Loss(),
+        task=RegressionTask(),
+        burnin_epochs=1,
+    )
+    monkeypatch.setattr(burnin, "log", lambda *args, **kwargs: None)
+    loss = burnin.training_step(
+        {"input": torch.zeros(1, 2), "target": torch.zeros(1, 1)}, 0
+    )
+    assert loss.shape == ()

--- a/tests/uq_methods/test_tasks.py
+++ b/tests/uq_methods/test_tasks.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Tests for immutable task values and their strict serialization boundary."""
+
+import json
+from typing import Any
+
+import pytest
+from torch import nn
+
+from lightning_uq_box.uq_methods import (
+    ClassificationTask,
+    Deterministic,
+    PixelRegressionTask,
+    RegressionTask,
+    SegmentationTask,
+    task_from_mapping,
+)
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        RegressionTask(),
+        ClassificationTask(mode="multiclass"),
+        SegmentationTask(mode="multilabel"),
+        PixelRegressionTask(),
+    ],
+)
+def test_task_mapping_round_trip(task) -> None:
+    """Every task is JSON-safe and round-trips through its allow-list."""
+    serialized = json.loads(json.dumps(task.to_mapping()))
+    assert task_from_mapping(serialized) == task
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        {
+            "version": 2,
+            "class_path": "lightning_uq_box.uq_methods.tasks.RegressionTask",
+            "init_args": {},
+        },
+        {"version": 1, "class_path": "builtins.object", "init_args": {}},
+        {
+            "version": 1,
+            "class_path": "lightning_uq_box.uq_methods.tasks.RegressionTask",
+            "init_args": {"unknown": True},
+        },
+    ],
+)
+def test_task_mapping_rejects_unrecognized_data(mapping) -> None:
+    """Checkpoint task data cannot import paths or add unreviewed fields."""
+    with pytest.raises(ValueError):
+        task_from_mapping(mapping)
+
+
+def test_task_accepts_hydra_and_lightning_cli_dialects() -> None:
+    """Both supported config syntaxes construct the same task value."""
+    target = "lightning_uq_box.uq_methods.tasks.ClassificationTask"
+    expected = ClassificationTask(mode="multilabel")
+    assert task_from_mapping({"_target_": target, "mode": "multilabel"}) == expected
+    assert (
+        task_from_mapping({"class_path": target, "init_args": {"mode": "multilabel"}})
+        == expected
+    )
+
+
+def test_legacy_multilable_is_normalized_and_warned() -> None:
+    """The historical spelling remains a warning-only compatibility path."""
+    legacy_mode: Any = "multilable"
+    with pytest.warns(DeprecationWarning):
+        task = ClassificationTask(mode=legacy_mode)
+    assert task.mode == "multilabel"
+
+
+def test_task_saved_as_mapping_not_object() -> None:
+    """Canonical hyperparameters never capture a TaskSpec object."""
+    module = Deterministic(nn.Linear(2, 1), nn.MSELoss(), task=RegressionTask())
+    saved_task = dict(module.hparams)["task"]
+    assert saved_task == RegressionTask().to_mapping()
+    assert not isinstance(saved_task, RegressionTask)

--- a/tests/uq_methods/test_tasks.py
+++ b/tests/uq_methods/test_tasks.py
@@ -4,7 +4,7 @@
 """Tests for immutable task values and their strict serialization boundary."""
 
 import json
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from torch import nn
@@ -15,6 +15,7 @@ from lightning_uq_box.uq_methods import (
     PixelRegressionTask,
     RegressionTask,
     SegmentationTask,
+    normalize_task,
     task_from_mapping,
 )
 
@@ -81,3 +82,67 @@ def test_task_saved_as_mapping_not_object() -> None:
     saved_task = dict(module.hparams)["task"]
     assert saved_task == RegressionTask().to_mapping()
     assert not isinstance(saved_task, RegressionTask)
+
+
+def test_task_classmethod_and_normalization_cover_public_entry_points() -> None:
+    """Task values, supported mappings, and explicit defaults normalize safely."""
+    mapping = RegressionTask().to_mapping()
+    assert RegressionTask.from_mapping(mapping) == RegressionTask()
+    assert normalize_task(RegressionTask()) == RegressionTask()
+    assert normalize_task(mapping) == RegressionTask()
+    assert normalize_task(None, default=PixelRegressionTask()) == PixelRegressionTask()
+
+
+@pytest.mark.parametrize(
+    "mode, binary_encoding",
+    [("not-a-mode", "one_logit"), ("binary", "not-an-encoding")],
+)
+def test_classification_task_rejects_invalid_semantics(
+    mode: Any, binary_encoding: Any
+) -> None:
+    """Invalid modes and probability encodings fail before model construction."""
+    with pytest.raises(ValueError):
+        ClassificationTask(mode=mode, binary_encoding=binary_encoding)
+
+
+@pytest.mark.parametrize(
+    "mapping, exception",
+    [
+        (
+            {
+                "_target_": "lightning_uq_box.uq_methods.tasks.RegressionTask",
+                "unexpected": True,
+            },
+            ValueError,
+        ),
+        (
+            {
+                "class_path": "lightning_uq_box.uq_methods.tasks.RegressionTask",
+                "init_args": {},
+                "unexpected": True,
+            },
+            ValueError,
+        ),
+        ({"not_a_task": True}, TypeError),
+        (
+            {
+                "class_path": "lightning_uq_box.uq_methods.tasks.RegressionTask",
+                "init_args": [],
+            },
+            TypeError,
+        ),
+        ({"_target_": "builtins.object"}, ValueError),
+    ],
+)
+def test_task_mapping_rejects_every_untrusted_shape(
+    mapping: dict[str, Any], exception
+) -> None:
+    """The task deserializer has no dynamic import or ignored-field fallback."""
+    with pytest.raises(exception):
+        task_from_mapping(mapping)
+
+
+def test_normalize_task_rejects_non_task_values() -> None:
+    """Only task values, allow-listed mappings, and ``None`` are accepted."""
+    with pytest.raises(TypeError):
+        normalize_task(cast(Any, "regression"))

--- a/tests/uq_methods/test_utils.py
+++ b/tests/uq_methods/test_utils.py
@@ -3,19 +3,24 @@
 
 """Test Utilities for UQ-Methods."""
 
+import json
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 import torch
 from conftest import minimal_cli_overrides
 
+import lightning_uq_box.uq_methods.utils as uq_utils
 from lightning_uq_box.main import get_uq_box_cli
 from lightning_uq_box.uq_methods.utils import (
     checkpoint_loader,
     default_classification_metrics,
+    default_regression_metrics,
     default_segmentation_metrics,
     process_classification_prediction,
+    process_segmentation_prediction,
     save_classification_predictions,
 )
 
@@ -162,3 +167,78 @@ def test_save_classification_predictions_multilabel(tmp_path: Path) -> None:
         assert df[f"class_prob_{i}"].tolist() == pytest.approx(
             class_probs[:, i].tolist()
         )
+
+
+def test_binary_prediction_helpers_preserve_single_item_batches() -> None:
+    """One-logit vector and dense conversions never squeeze the batch axis."""
+    classification_logits = torch.tensor([[[1.0, -1.0]]])
+    classification = process_classification_prediction(
+        classification_logits, task="binary", binary_encoding="one_logit"
+    )
+    assert classification["pred"].shape == (1, 1)
+    assert classification["pred_uct"].shape == (1,)
+
+    segmentation_logits = torch.zeros(1, 1, 2, 2, 2)
+    segmentation = process_segmentation_prediction(
+        segmentation_logits, task="binary", binary_encoding="one_logit"
+    )
+    assert segmentation["pred"].shape == (1, 1, 2, 2)
+    assert segmentation["pred_uct"].shape == (1, 2, 2)
+
+
+def test_canonical_metric_and_writer_helpers_cover_edge_shapes(tmp_path: Path) -> None:
+    """Canonical helpers support B=1 without restoring legacy squeeze behavior."""
+    assert "R2" in default_regression_metrics("test")
+    assert "R2" not in default_regression_metrics("test", include_r2=False)
+    binary = default_classification_metrics("test", "binary", 1)
+    assert binary(torch.tensor([0.8]), torch.tensor([1]))
+    assert uq_utils._writer_array(torch.ones(1, 1)).shape == (1,)
+    assert uq_utils._writer_array(torch.tensor(1.0)).shape == (1,)
+    assert np.array_equal(uq_utils._writer_array([1, 2]), np.array([1, 2]))
+
+    outputs = {
+        "pred": torch.tensor([0.8]),
+        "target": torch.tensor([1]),
+        "samples": torch.tensor([[0.8, 0.7]]),
+        "logits": torch.tensor([[1.0]]),
+        "pred_set": [torch.tensor([True, False])],
+    }
+    path = tmp_path / "nested" / "preds.csv"
+    save_classification_predictions(
+        outputs, str(path), task="binary", binary_encoding="one_logit"
+    )
+    assert set(outputs) == {"pred", "target", "samples", "logits", "pred_set"}
+    assert pd.read_csv(path)["pred"].tolist() == [1]
+
+
+def test_distributed_paths_are_rank_sharded_with_a_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Distributed writers never share a filename and rank zero publishes discovery."""
+    monkeypatch.setattr(uq_utils.torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(uq_utils.torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(uq_utils.torch.distributed, "get_world_size", lambda: 2)
+    monkeypatch.setattr(uq_utils.torch.distributed, "get_rank", lambda: 0)
+    path = tmp_path / "preds.csv"
+    assert uq_utils._distributed_path(str(path)) == str(tmp_path / "preds.rank-0.csv")
+    manifest = json.loads((tmp_path / "preds.manifest.json").read_text())
+    assert manifest == {
+        "version": 1,
+        "world_size": 2,
+        "shards": ["preds.rank-0.csv", "preds.rank-1.csv"],
+    }
+    monkeypatch.setattr(uq_utils.torch.distributed, "get_rank", lambda: 1)
+    assert uq_utils._distributed_path(str(path)) == str(tmp_path / "preds.rank-1.csv")
+
+
+def test_distributed_path_keeps_single_process_filename(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Unavailable and single-rank distributed backends preserve legacy paths."""
+    path = str(tmp_path / "preds.csv")
+    monkeypatch.setattr(uq_utils.torch.distributed, "is_available", lambda: False)
+    assert uq_utils._distributed_path(path) == path
+    monkeypatch.setattr(uq_utils.torch.distributed, "is_available", lambda: True)
+    monkeypatch.setattr(uq_utils.torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(uq_utils.torch.distributed, "get_world_size", lambda: 1)
+    assert uq_utils._distributed_path(path) == path


### PR DESCRIPTION
Summary:
- Introduce frozen serializable task values, output/capability contracts, a private task runtime, and non-mutating prediction writers.
- Add canonical task-aware Deterministic and MCDropout APIs while retaining 0.4 legacy adapters with deprecation warnings.
- Add canonical configs, focused contract and adapter tests, version-change documentation, and working transformed tutorials.
- Add docs/method_task_transition.md: an ordered 15-PR follow-up stack with ownership, prerequisites, and acceptance checks.

Scope boundary:
This is the foundational vertical slice. It does not claim that the complete method inventory, all configuration classifications, distributed writer fixture, or every checkpoint baseline is finished. Those steps are explicitly ordered in the transition roadmap so subsequent PRs can stack cleanly.

Validation:
- ruff check for uq_methods and its tests
- ty check
- focused task, contract, writer, adapter, and public-API pytest suite: 28 passed
- Sphinx HTML build with notebook execution disabled