### PR TITLE
Add hierarchical probabilistic U-Net with SMP encoders and GECO

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following sections aims to give an overview of different UQ-Methods by group
 |-----------------------------------------------|:----------:|:--------------:|:------------:|:---------------------:|
 | Classification And Regression Diffusion (CARD)|     ✅     |       ✅       |      ❌      |          ❌           |
 | Probabilistic UNet                            |     ❌     |       ❌       |      ✅      |          ❌           |       |
+| Hierarchical Probabilistic UNet                |     ❌     |       ❌       |      ✅      |          ❌           |
 | Variational Auto-Encoder (VAE)                |     ❌     |       ❌       |      ❌      |          ✅           |
 | Vector Quantized VAE (VQ-VAE)                 |     ❌     |       ❌       |      ❌      |          ✅           |
 

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -12,3 +12,9 @@ lightning_uq_box.models
 .. autoclass:: EnsemblePriorFunction
 
 .. autoclass:: ConvEnsemblePriorFunction
+
+.. autoclass:: HierarchicalProbUNet
+
+.. autoclass:: HierarchicalUnetDecoder
+
+.. autoclass:: PreActResBlock

--- a/docs/api/uq_methods.rst
+++ b/docs/api/uq_methods.rst
@@ -441,6 +441,51 @@ Probabilistic UNet
 
 
 
+Hierarchical Probabilistic UNet
+-------------------------------
+
+.. currentmodule:: lightning_uq_box.uq_methods.hierarchical_prob_unet
+
+.. autoclass:: HierarchicalProbUNet
+
+.. autofunction:: hierarchical_ce_loss
+
+This SMP adaptation of `Kohl et al. (2019) <https://arxiv.org/abs/1905.13077>`_
+uses separate image prior and image/segmentation posterior encoders. Posterior
+samples condition the prior at every latent scale for reconstruction and KL.
+Prediction samples only the prior. ``mean`` can be a boolean per scale to explore
+coarse-to-fine interventions.
+
+GECO is the default: reconstruction CE is summed over selected pixels and
+averaged over images; ``kappa`` is scaled by the selected pixel count. Hard pixel
+mining selects 2% over the whole batch with Gumbel-perturbed ranking. The moving
+average uses a straight-through reconstruction gradient. The multiplier is a
+checkpointed buffer updated once per training batch, independently of optimizer
+and scheduler, and synchronized across distributed ranks. A sustained multiplier
+at its 1e5 cap suggests an unattainable reconstruction target. Set
+``loss_type="elbo"`` for fixed-beta training. Binary tasks use one sigmoid logit;
+multiclass tasks use one logit per class.
+
+For a small dataset, use ``encoder_weights="imagenet"`` with
+``freeze_backbone=True`` to train the latent hierarchy with frozen encoders.
+``freeze_decoder=True`` freezes only the prior's deterministic stitching tail
+and segmentation head; stochastic stages remain trainable.
+
+The SMP backbone and decoder differ from the paper's eight-scale residual
+architecture. ``blocks_per_level`` and ``convs_per_block`` control residual
+refinement before each latent head; SMP blocks perform upsampling and skip
+fusion. The posterior ends at its last distribution, and training omits the
+unused free-prior pass from the reference. Report parameter counts and training
+settings when comparing to the paper; paper-level LIDC scores are not implied
+by architecture or smoke tests.
+
+Distributional evaluation uses integer maps ``[B, N, H, W]``, obtained by argmax
+of individual sampled logits (threshold for binary). The functions in
+``lightning_uq_box.eval_utils`` provide reconstruction IoU, squared GED and
+balanced Hungarian IoU with empty-vs-empty IoU equal to one. Always report the
+GED diversity term ``d_ss`` alongside GED. For non-divisible sample/grader counts,
+Hungarian evaluation repeats both sets to their least common multiple.
+
 UQ Calibration Methods
 ======================
 

--- a/docs/tutorials/earth_observation.md
+++ b/docs/tutorials/earth_observation.md
@@ -6,4 +6,5 @@
 :maxdepth: 1
 
 earth_observation/raps
+earth_observation/hierarchical_prob_unet
 ```

--- a/docs/tutorials/earth_observation/hierarchical_prob_unet.ipynb
+++ b/docs/tutorials/earth_observation/hierarchical_prob_unet.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "hpunet-0",
+   "metadata": {},
+   "source": [
+    "# Hierarchical Probabilistic U-Net: spatial latent interventions\n",
+    "\n",
+    "The [hierarchical Probabilistic U-Net](https://arxiv.org/abs/1905.13077) conditions each finer latent distribution on the coarser samples. This tutorial uses an SMP encoder and the toolbox toy segmentation data, with no pretrained-weight download. It demonstrates training, prior sampling, and per-scale interventions. A brief toy run cannot establish the scale disentanglement or LIDC accuracy reported in the paper.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hpunet-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright (c) 2023 lightning-uq-box. All rights reserved.\n",
+    "# Licensed under the Apache License 2.0.\n",
+    "from functools import partial\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "from lightning import Trainer, seed_everything\n",
+    "\n",
+    "from lightning_uq_box.datamodules import ToySegmentationDataModule\n",
+    "from lightning_uq_box.models import HierarchicalProbUNet as HierarchicalModel\n",
+    "from lightning_uq_box.uq_methods import HierarchicalProbUNet\n",
+    "\n",
+    "seed_everything(0)\n",
+    "torch.set_num_threads(2)\n",
+    "data = ToySegmentationDataModule(batch_size=4)\n",
+    "model = HierarchicalModel(\n",
+    "    encoder_name=\"resnet18\",\n",
+    "    encoder_weights=None,\n",
+    "    classes=4,\n",
+    "    latent_dims=(1, 1),\n",
+    "    decoder_channels=(32, 16, 8, 4, 2),\n",
+    ")\n",
+    "method = HierarchicalProbUNet(\n",
+    "    model, num_classes=4, num_samples=4, optimizer=partial(torch.optim.Adam, lr=1e-4)\n",
+    ")\n",
+    "trainer = Trainer(\n",
+    "    max_steps=20,\n",
+    "    accelerator=\"cpu\",\n",
+    "    devices=1,\n",
+    "    logger=False,\n",
+    "    enable_checkpointing=False,\n",
+    "    gradient_clip_val=1.0,\n",
+    "    limit_val_batches=1,\n",
+    "    enable_model_summary=False,\n",
+    ")\n",
+    "trainer.fit(method, datamodule=data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hpunet-2",
+   "metadata": {},
+   "source": [
+    "## Sample segmentations and inspect uncertainty\n",
+    "\n",
+    "Training uses posterior samples and evaluates the prior on those same samples. At prediction time, only the image is available and all samples come from the prior. `pred` is the mean probability map; `logits` retains each sample.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hpunet-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "method.eval()\n",
+    "batch = next(iter(data.val_dataloader()))\n",
+    "image = batch[\"input\"][:1]\n",
+    "with torch.no_grad():\n",
+    "    predictions = method.predict_step(image)\n",
+    "print(\"Sample logits:\", tuple(predictions[\"logits\"].shape))\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(10, 3))\n",
+    "axes[0].imshow(image[0].movedim(0, -1).numpy())\n",
+    "axes[0].set_title(\"Input\")\n",
+    "axes[1].imshow(predictions[\"pred\"].argmax(1)[0], vmin=0, vmax=3)\n",
+    "axes[1].set_title(\"Mean prediction\")\n",
+    "axes[2].imshow(predictions[\"pred_uct\"][0].squeeze(), cmap=\"magma\")\n",
+    "axes[2].set_title(\"Predictive entropy\")\n",
+    "for ax in axes:\n",
+    "    ax.axis(\"off\")\n",
+    "plt.show()\n",
+    "plt.close(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hpunet-4",
+   "metadata": {},
+   "source": [
+    "## Intervene at one scale\n",
+    "\n",
+    "First fix every latent at its conditional prior mean. In each row below, resample one scale while using conditional means at the others. Because the hierarchy is autoregressive, a coarse intervention also changes the means of downstream distributions. Use the `z_q` argument with saved latent tensors instead if you need to hold their numeric values fixed.\n",
+    "\n",
+    "For a trained LIDC model, inspect whether coarse changes affect lesion presence or structure and fine changes affect boundaries. Also inspect per-scale `train_kl_i`, `train_lagmul`, and held-out reconstruction IoU; visually different samples alone do not establish disentanglement.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hpunet-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scales = len(model.latent_dims)\n",
+    "fig, axes = plt.subplots(scales, 5, figsize=(12, 3 * scales), squeeze=False)\n",
+    "with torch.no_grad():\n",
+    "    baseline = model.sample(image, mean=True).argmax(1)[0]\n",
+    "    for scale in range(scales):\n",
+    "        flags = [True] * scales\n",
+    "        flags[scale] = False\n",
+    "        axes[scale, 0].imshow(baseline, vmin=0, vmax=3)\n",
+    "        axes[scale, 0].set_title(\"All means\")\n",
+    "        for col in range(1, 5):\n",
+    "            sample = model.sample(image, mean=flags).argmax(1)[0]\n",
+    "            axes[scale, col].imshow(sample, vmin=0, vmax=3)\n",
+    "            axes[scale, col].set_title(f\"Scale {scale}, draw {col}\")\n",
+    "for ax in axes.flat:\n",
+    "    ax.axis(\"off\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "plt.close(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "hpunet-6",
+   "metadata": {},
+   "source": [
+    "## Evaluate multiple annotations\n",
+    "\n",
+    "Given integer prior maps `samples` of shape `[B, N, H, W]` and grader maps `graders` of shape `[B, M, H, W]`, call `generalized_energy_distance(samples, graders, num_classes)` and `hungarian_matched_iou(samples, graders, num_classes)` from `lightning_uq_box.eval_utils`. Report GED squared together with `d_ss` and matched IoU. Empty foreground in both masks scores IoU 1.\n",
+    "\n",
+    "For LIDC, use the same SMP backbone and preprocessing as the flat baseline. The flat model uses its own beta-ELBO loss while this model defaults to GECO. These are a controlled backbone comparison, not an exact replication of the paper's original networks.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/lightning_uq_box/eval_utils/__init__.py
+++ b/lightning_uq_box/eval_utils/__init__.py
@@ -12,6 +12,12 @@ from .joint_prediction import (
     marginal_log_likelihood,
     marginal_log_loss,
 )
+from .segmentation_distribution import (
+    generalized_energy_distance,
+    hungarian_matched_iou,
+    iou_with_empty_convention,
+    reconstruction_iou,
+)
 from .uq_computation import (
     compute_aleatoric_uncertainty,
     compute_empirical_coverage,
@@ -22,6 +28,11 @@ from .uq_computation import (
 )
 
 __all__ = (
+    # segmentation distribution metrics
+    "generalized_energy_distance",
+    "hungarian_matched_iou",
+    "iou_with_empty_convention",
+    "reconstruction_iou",
     # evaluation utils 1d regression
     "compute_aleatoric_uncertainty",
     "compute_empirical_coverage",

--- a/lightning_uq_box/eval_utils/segmentation_distribution.py
+++ b/lightning_uq_box/eval_utils/segmentation_distribution.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Distributional segmentation metrics on hard labels, with empty IoU equal to one."""
+
+import math
+
+import torch
+from scipy.optimize import linear_sum_assignment
+from torch import Tensor
+
+
+def _check_labels(labels: Tensor, num_classes: int) -> None:
+    if labels.is_floating_point() or labels.is_complex():
+        raise ValueError("Metrics require integer hard label maps, not probabilities.")
+    if num_classes < 2 or labels.numel() == 0:
+        raise ValueError("Require nonempty labels and num_classes >= 2.")
+    if (labels < 0).any() or (labels >= num_classes).any():
+        raise ValueError("Label values must be in [0, num_classes).")
+
+
+def iou_with_empty_convention(
+    pred: Tensor, target: Tensor, num_classes: int, ignore_background: bool = True
+) -> Tensor:
+    """Return IoU per leading index for hard maps [..., H, W].
+
+    Shapes may broadcast (useful for pairwise comparisons). Average over classes,
+    excluding class zero by default; each absent-in-both class scores one.
+    """
+    _check_labels(pred, num_classes)
+    _check_labels(target, num_classes)
+    if pred.ndim < 2 or target.ndim < 2 or pred.shape[-2:] != target.shape[-2:]:
+        raise ValueError("Hard maps must have matching spatial dimensions.")
+    scores = []
+    for label in range(int(ignore_background), num_classes):
+        p, t = pred == label, target == label
+        intersection = (p & t).sum(dim=(-2, -1))
+        union = (p | t).sum(dim=(-2, -1))
+        scores.append(
+            torch.where(union == 0, 1.0, intersection.float() / union.clamp_min(1))
+        )
+    return torch.stack(scores).mean(0)
+
+
+def _pairwise_iou(
+    a: Tensor, b: Tensor, num_classes: int, ignore_background: bool
+) -> Tensor:
+    _check_labels(a, num_classes)
+    _check_labels(b, num_classes)
+    if a.ndim != 4 or b.ndim != 4 or a.shape[0] != b.shape[0]:
+        raise ValueError("Expected [B, num_maps, H, W] with matching batch sizes.")
+    # Iterate one sample axis to avoid materializing [B, N, M, H, W].
+    return torch.stack(
+        [
+            iou_with_empty_convention(x[:, None], b, num_classes, ignore_background)
+            for x in a.unbind(1)
+        ],
+        dim=1,
+    )
+
+
+def generalized_energy_distance(
+    samples: Tensor, graders: Tensor, num_classes: int, ignore_background: bool = True
+) -> dict[str, Tensor]:
+    """Compute squared GED and its three per-image terms using 1 - IoU.
+
+    Args:
+        samples: Hard label maps [B, N, H, W].
+        graders: Hard grader maps [B, M, H, W].
+        num_classes: Number of classes including background.
+        ignore_background: Exclude class zero from IoU.
+
+    Returns:
+        V-statistic GED squared (key ``ged``), ``d_sy``, ``d_ss``, ``d_yy``,
+        each [B]. Self-pairs are included. Always report diversity ``d_ss``
+        alongside GED: increasing diversity alone can improve GED.
+    """
+    d_sy = (1 - _pairwise_iou(samples, graders, num_classes, ignore_background)).mean(
+        (1, 2)
+    )
+    d_ss = (1 - _pairwise_iou(samples, samples, num_classes, ignore_background)).mean(
+        (1, 2)
+    )
+    d_yy = (1 - _pairwise_iou(graders, graders, num_classes, ignore_background)).mean(
+        (1, 2)
+    )
+    return {"ged": 2 * d_sy - d_ss - d_yy, "d_sy": d_sy, "d_ss": d_ss, "d_yy": d_yy}
+
+
+def hungarian_matched_iou(
+    samples: Tensor, graders: Tensor, num_classes: int, ignore_background: bool = True
+) -> Tensor:
+    """Return optimal balanced IoU [B] for hard maps [B, N/M, H, W].
+
+    Repeat each set to their least common multiple so every grader has equal
+    weight, including non-divisible sample counts. Assignment runs on CPU and
+    is intended for evaluation, not differentiable training.
+    """
+    iou = _pairwise_iou(samples, graders, num_classes, ignore_background)
+    n, m = iou.shape[1:]
+    size = math.lcm(n, m)
+    balanced = iou.repeat_interleave(size // n, dim=1).repeat_interleave(
+        size // m, dim=2
+    )
+    scores = []
+    for matrix in balanced:
+        rows, cols = linear_sum_assignment((1 - matrix).detach().cpu().numpy())
+        scores.append(
+            matrix[
+                torch.as_tensor(rows, device=matrix.device),
+                torch.as_tensor(cols, device=matrix.device),
+            ].mean()
+        )
+    return torch.stack(scores)
+
+
+def reconstruction_iou(
+    pred: Tensor, target: Tensor, num_classes: int, ignore_background: bool = True
+) -> Tensor:
+    """Return posterior reconstruction IoU_rec [B] for hard maps [B, H, W]."""
+    return iou_with_empty_convention(pred, target, num_classes, ignore_background)

--- a/lightning_uq_box/models/__init__.py
+++ b/lightning_uq_box/models/__init__.py
@@ -17,10 +17,18 @@ from .epinet import (
     ProjectedMLP,
 )
 from .fc_resnet import FCResNet
+from .hierarchical_prob_unet import (
+    HierarchicalProbUNet,
+    HierarchicalUnetDecoder,
+    PreActResBlock,
+)
 from .mixture_density import MixtureDensityLayer
 from .mlp import MLP
 
 __all__ = (
+    "HierarchicalProbUNet",
+    "HierarchicalUnetDecoder",
+    "PreActResBlock",
     # Toy Example architecture
     "MLP",
     # Mixture Density Layer

--- a/lightning_uq_box/models/hierarchical_prob_unet.py
+++ b/lightning_uq_box/models/hierarchical_prob_unet.py
@@ -1,0 +1,327 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""SMP-backed hierarchical spatial latent U-Net (Kohl et al., 2019)."""
+
+from collections.abc import Sequence
+from typing import NamedTuple
+
+import torch
+from segmentation_models_pytorch.base import SegmentationHead
+from segmentation_models_pytorch.decoders.unet.decoder import (
+    UnetDecoder,
+    UnetDecoderBlock,
+)
+from segmentation_models_pytorch.encoders import get_encoder
+from torch import Tensor, nn
+from torch.distributions import Independent, Normal
+
+from .prob_unet import init_weights_orthogonal_normal
+
+
+class PreActResBlock(nn.Module):
+    """Pre-activated residual block without normalization."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        down_channels: int | None = None,
+        convs_per_block: int = 3,
+    ) -> None:
+        """Initialize projections and ReLU/3x3 convolutions at the inner width."""
+        super().__init__()
+        width = down_channels if down_channels is not None else out_channels
+        if min(in_channels, out_channels, width, convs_per_block) < 1:
+            raise ValueError("Channel counts and convs_per_block must be positive.")
+        self.input_projection = (
+            nn.Conv2d(in_channels, width, 1) if in_channels != width else nn.Identity()
+        )
+        self.output_projection = (
+            nn.Conv2d(width, out_channels, 1)
+            if width != out_channels
+            else nn.Identity()
+        )
+        self.skip_projection = (
+            nn.Conv2d(in_channels, out_channels, 1)
+            if in_channels != out_channels
+            else nn.Identity()
+        )
+        self.convs = nn.Sequential(
+            *[
+                layer
+                for _ in range(convs_per_block)
+                for layer in (nn.ReLU(), nn.Conv2d(width, width, 3, padding=1))
+            ]
+        )
+        self.apply(init_weights_orthogonal_normal)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Map [B, in_channels, H, W] to [B, out_channels, H, W]."""
+        return self.skip_projection(x) + self.output_projection(
+            self.convs(self.input_projection(x))
+        )
+
+
+class HierarchicalCoreOutput(NamedTuple):
+    """Decoder features, encoder features, NHWC distributions and NCHW latents."""
+
+    decoder_features: Tensor
+    encoder_features: list[Tensor]
+    distributions: list[Independent]
+    used_latents: list[Tensor]
+
+
+class HierarchicalUnetDecoder(UnetDecoder):
+    """SMP decoder with autoregressive spatial Gaussians before upsampling."""
+
+    def __init__(
+        self,
+        encoder_channels: Sequence[int],
+        decoder_channels: Sequence[int],
+        n_blocks: int = 5,
+        latent_dims: Sequence[int] = (1, 1, 1, 1),
+        use_norm: str | bool = "batchnorm",
+        interpolation_mode: str = "nearest",
+        convs_per_block: int = 3,
+        blocks_per_level: int = 1,
+        posterior: bool = False,
+    ) -> None:
+        """Initialize stochastic stages and a deterministic stitching tail.
+
+        The posterior stops at its last distribution: subsequent decoder blocks
+        cannot affect any posterior latent and would be unused trainable weights.
+        Additional residual blocks refine each stochastic feature before its head.
+        """
+        if not 0 < len(latent_dims) < n_blocks or any(d < 1 for d in latent_dims):
+            raise ValueError(
+                "latent_dims must be positive and leave at least one deterministic stitching stage."
+            )
+        if blocks_per_level < 1 or convs_per_block < 1:
+            raise ValueError("blocks_per_level and convs_per_block must be positive.")
+        super().__init__(
+            encoder_channels,
+            decoder_channels,
+            n_blocks=n_blocks,
+            use_norm=use_norm,
+            interpolation_mode=interpolation_mode,
+        )
+        self.latent_dims = tuple(latent_dims)
+        self.posterior = posterior
+        # Channel arithmetic from segmentation_models_pytorch/decoders/unet/decoder.py.
+        channels = list(encoder_channels[1:])[::-1]
+        inputs = [channels[0], *decoder_channels[:-1]]
+        skips = [*channels[1:], 0]
+        self.latent_heads = nn.ModuleList()
+        self.refinements = nn.ModuleList()
+        for i, dim in enumerate(latent_dims):
+            self.latent_heads.append(nn.Conv2d(inputs[i], 2 * dim, 1))
+            self.refinements.append(
+                nn.Sequential(
+                    *[
+                        PreActResBlock(
+                            inputs[i],
+                            inputs[i],
+                            max(1, inputs[i] // 2),
+                            convs_per_block,
+                        )
+                        for _ in range(blocks_per_level)
+                    ]
+                )
+            )
+            self.blocks[i] = UnetDecoderBlock(
+                inputs[i] + dim,
+                skips[i],
+                decoder_channels[i],
+                use_norm=use_norm,
+                interpolation_mode=interpolation_mode,
+            )
+        if posterior:
+            self.blocks = self.blocks[: len(latent_dims) - 1]
+        self.latent_heads.apply(init_weights_orthogonal_normal)
+
+    # SMP annotates forward as Tensor; this decoder also returns latent distributions.
+    def forward(  # ty: ignore[invalid-method-override]
+        self,
+        features: list[Tensor],
+        mean: bool | Sequence[bool] = False,
+        z_q: Sequence[Tensor] | None = None,
+    ) -> HierarchicalCoreOutput:
+        """Decode encoder features, optionally forcing NCHW latents at every scale.
+
+        Args:
+            features: SMP encoder features, finest to coarsest.
+            mean: Use Gaussian means globally or separately at each scale.
+            z_q: Optional latent maps [B, latent_dims[i], H_i, W_i].
+
+        Returns:
+            Features, distributions with batch shape [B, H_i, W_i] and
+            event shape [latent_dims[i]], and the exact latents used.
+        """
+        means = [mean] * len(self.latent_dims) if isinstance(mean, bool) else list(mean)
+        if len(means) != len(self.latent_dims) or (
+            z_q is not None and len(z_q) != len(means)
+        ):
+            raise ValueError("Provide one mean flag and one external latent per scale.")
+        shapes = [f.shape[-2:] for f in features][::-1]
+        reversed_features = features[1:][::-1]
+        x = self.center(reversed_features[0])
+        distributions: list[Independent] = []
+        latents: list[Tensor] = []
+        for i in range(max(len(self.blocks), len(self.latent_dims))):
+            if i < len(self.latent_dims):
+                x = self.refinements[i](x)
+                mu, log_sigma = self.latent_heads[i](x).chunk(2, dim=1)
+                # Channels form the event; spatial locations remain batch axes.
+                # Bound log scales and compute distributions in FP32 to prevent
+                # exp/variance overflow under mixed precision or early GECO updates.
+                dist = Independent(
+                    Normal(
+                        mu.float().movedim(1, -1),
+                        log_sigma.float().clamp(-10, 10).movedim(1, -1).exp(),
+                    ),
+                    1,
+                )
+                z = (
+                    z_q[i]
+                    if z_q is not None
+                    else (dist.mean if means[i] else dist.rsample()).movedim(-1, 1)
+                )
+                if z.shape != mu.shape:
+                    raise ValueError(
+                        f"Latent {i} has shape {z.shape}; expected {mu.shape}."
+                    )
+                distributions.append(dist)
+                latents.append(z)
+                x = torch.cat([x, z], dim=1)
+            if i < len(self.blocks):
+                skip = (
+                    reversed_features[i + 1] if i + 1 < len(reversed_features) else None
+                )
+                x = self.blocks[i](x, *shapes[i + 1], skip_connection=skip)
+        return HierarchicalCoreOutput(x, features, distributions, latents)
+
+
+class HierarchicalProbUNet(nn.Module):
+    """Hierarchical Probabilistic U-Net with independent SMP prior/posterior encoders.
+
+    This adapts the spatial latent hierarchy to SMP, rather than reproducing the
+    paper's eight-scale residual encoder. Inputs are NCHW; outputs are logits.
+    """
+
+    def __init__(
+        self,
+        encoder_name: str = "resnet34",
+        encoder_depth: int = 5,
+        encoder_weights: str | None = "imagenet",
+        decoder_channels: Sequence[int] = (256, 128, 64, 32, 16),
+        in_channels: int = 3,
+        classes: int = 2,
+        latent_dims: Sequence[int] = (1, 1, 1, 1),
+        convs_per_block: int = 3,
+        blocks_per_level: int = 1,
+        decoder_use_norm: str | bool = "batchnorm",
+        decoder_interpolation: str = "nearest",
+    ) -> None:
+        """Build two encoders, spatial latent decoders and the prior's output head.
+
+        Args:
+            encoder_name: SMP encoder name.
+            encoder_depth: Number of downsampling stages.
+            encoder_weights: Pretrained encoder weights or None.
+            decoder_channels: Output widths, one per upsampling stage.
+            in_channels: Image channels.
+            classes: Segmentation logit channels (one for sigmoid binary output).
+            latent_dims: Latent channels at each coarse-to-fine stochastic scale.
+            convs_per_block: Convolutions in each pre-head residual block.
+            blocks_per_level: Pre-head residual blocks at each stochastic scale.
+            decoder_use_norm: SMP decoder normalization; False disables it.
+            decoder_interpolation: SMP upsampling interpolation mode.
+        """
+        super().__init__()
+        if classes < 1 or in_channels < 1:
+            raise ValueError("classes and in_channels must be positive.")
+        if (
+            len(decoder_channels) != encoder_depth
+            or not 0 < len(latent_dims) < encoder_depth
+        ):
+            raise ValueError(
+                "Match decoder_channels to encoder_depth and leave a deterministic stitching stage."
+            )
+        self.classes = classes
+        self.in_channels = in_channels
+        self.latent_dims = tuple(latent_dims)
+        self.prior_encoder = get_encoder(
+            encoder_name,
+            in_channels=in_channels,
+            depth=encoder_depth,
+            weights=encoder_weights,
+        )
+        self.posterior_encoder = get_encoder(
+            encoder_name,
+            in_channels=in_channels + classes,
+            depth=encoder_depth,
+            weights=encoder_weights,
+        )
+        self.prior_decoder = HierarchicalUnetDecoder(
+            self.prior_encoder.out_channels,
+            decoder_channels,
+            encoder_depth,
+            latent_dims,
+            decoder_use_norm,
+            decoder_interpolation,
+            convs_per_block,
+            blocks_per_level,
+        )
+        self.posterior_decoder = HierarchicalUnetDecoder(
+            self.posterior_encoder.out_channels,
+            decoder_channels,
+            encoder_depth,
+            latent_dims,
+            decoder_use_norm,
+            decoder_interpolation,
+            convs_per_block,
+            blocks_per_level,
+            posterior=True,
+        )
+        self.segmentation_head = SegmentationHead(
+            decoder_channels[-1], classes, kernel_size=3
+        )
+        self.segmentation_head.apply(init_weights_orthogonal_normal)
+
+    def sample(
+        self,
+        img: Tensor,
+        mean: bool | Sequence[bool] = False,
+        z_q: Sequence[Tensor] | None = None,
+    ) -> Tensor:
+        """Generate [B, classes, H, W] logits from images and optional NCHW latents."""
+        out = self.prior_decoder(self.prior_encoder(img), mean=mean, z_q=z_q)
+        return self.segmentation_head(out.decoder_features)
+
+    def reconstruct(
+        self, img: Tensor, seg_one_hot: Tensor, mean: bool | Sequence[bool] = False
+    ) -> tuple[Tensor, list[Independent], list[Independent]]:
+        """Return posterior reconstruction logits and conditional q/p distributions.
+
+        Args:
+            img: Images [B, in_channels, H, W].
+            seg_one_hot: Soft or one-hot targets [B, classes, H, W].
+            mean: Use posterior means globally or per scale.
+        """
+        q = self.posterior_decoder(
+            self.posterior_encoder(torch.cat([img, seg_one_hot], dim=1)), mean=mean
+        )
+        p = self.prior_decoder(self.prior_encoder(img), z_q=q.used_latents)
+        # Reconstruction uses PRIOR features conditioned on posterior samples.
+        return (
+            self.segmentation_head(p.decoder_features),
+            q.distributions,
+            p.distributions,
+        )
+
+    def forward(
+        self, img: Tensor, seg_one_hot: Tensor, mean: bool | Sequence[bool] = False
+    ) -> tuple[Tensor, list[Independent], list[Independent]]:
+        """Run posterior and teacher-forced prior; omit the unused free-prior pass."""
+        return self.reconstruct(img, seg_one_hot, mean)

--- a/lightning_uq_box/uq_methods/__init__.py
+++ b/lightning_uq_box/uq_methods/__init__.py
@@ -49,6 +49,7 @@ from .density_uncertainty import (
 )
 from .deterministic_uncertainty_estimation import DUEClassification, DUERegression
 from .epinet import EpinetBase, EpinetClassification, EpinetRegression
+from .hierarchical_prob_unet import HierarchicalProbUNet
 from .img2img_conformal import Img2ImgConformal
 from .inference_time_augmentation import TTABase, TTAClassification, TTARegression
 from .laplace_model import LaplaceBase, LaplaceClassification, LaplaceRegression
@@ -104,6 +105,7 @@ from .vq_vae import VQVAE, VQVAEPrior
 from .zigzag import ZigZagBase, ZigZagClassification, ZigZagRegression
 
 __all__ = (
+    "HierarchicalProbUNet",
     # Base Module
     "BaseModule",
     "PosthocBase",

--- a/lightning_uq_box/uq_methods/hierarchical_prob_unet.py
+++ b/lightning_uq_box/uq_methods/hierarchical_prob_unet.py
@@ -1,0 +1,388 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+"""Hierarchical Probabilistic U-Net with GECO or fixed-beta ELBO training."""
+
+import math
+import os
+from collections.abc import Sequence
+from typing import Any, ClassVar, cast
+
+import torch
+import torch.nn.functional as F
+from lightning.pytorch.cli import LRSchedulerCallable, OptimizerCallable
+from lightning.pytorch.utilities.types import STEP_OUTPUT, OptimizerLRScheduler
+from torch import Tensor, nn
+from torch.distributions import Independent, kl_divergence
+
+from ..models.hierarchical_prob_unet import (
+    HierarchicalProbUNet as HierarchicalProbUNetModel,
+)
+from .base import BaseModule
+from .utils import (
+    default_segmentation_metrics,
+    process_segmentation_prediction,
+    save_image_predictions,
+)
+
+
+def hierarchical_ce_loss(
+    logits: Tensor,
+    target: Tensor,
+    top_k_percentage: float | None = 0.02,
+    deterministic_top_k: bool = False,
+    mask: Tensor | None = None,
+) -> dict[str, Tensor]:
+    """Compute soft-label CE, optionally mining hard pixels over the whole batch.
+
+    Args:
+        logits: Logits [B, C, H, W]; C=1 uses binary cross entropy.
+        target: Soft or one-hot targets of the same shape as logits.
+        top_k_percentage: Fraction of pixels selected, or None for all pixels.
+        deterministic_top_k: Rank CE directly instead of adding Gumbel noise.
+        mask: Optional binary valid-pixel mask [B, H, W] or [B, H*W].
+
+    Returns:
+        Batch-averaged pixel sum, selected-pixel mean and [B, H*W] mask.
+        At least one valid pixel is selected when rounding k would give zero.
+    """
+    if logits.ndim != 4 or logits.shape != target.shape:
+        raise ValueError("logits and target must have matching [B, C, H, W] shapes.")
+    if top_k_percentage is not None and not 0 < top_k_percentage <= 1:
+        raise ValueError("top_k_percentage must be in (0, 1] or None.")
+    if logits.shape[1] == 1:
+        xe = F.binary_cross_entropy_with_logits(
+            logits, target, reduction="none"
+        ).squeeze(1)
+    else:
+        xe = -(target * F.log_softmax(logits, dim=1)).sum(dim=1)
+    xe = xe.flatten(1)
+    valid = (
+        torch.ones_like(xe, dtype=torch.bool)
+        if mask is None
+        else mask.reshape_as(xe).bool()
+    )
+    selected = valid
+    if top_k_percentage is not None:
+        k = min(
+            max(1, math.floor(xe.numel() * top_k_percentage)), int(valid.sum().item())
+        )
+        scores = xe.detach().flatten()
+        # Normalizing before log only adds a constant and leaves the ranking unchanged.
+        scores = scores.clamp_min(torch.finfo(scores.dtype).tiny).log()
+        if not deterministic_top_k:
+            u = torch.rand_like(scores).clamp_(
+                torch.finfo(scores.dtype).eps, 1 - torch.finfo(scores.dtype).eps
+            )
+            scores = scores - (-u.log()).log()
+        scores = scores.masked_fill(~valid.flatten(), -torch.inf)
+        selected = torch.zeros_like(valid).flatten()
+        selected.scatter_(0, scores.topk(k).indices, True)
+        selected = selected.reshape_as(xe)
+    weights = selected.to(xe.dtype)
+    total = (xe * weights).sum()
+    return {
+        "sum": total / logits.shape[0],
+        "mean": total / weights.sum().clamp_min(1),
+        "mask": weights,
+    }
+
+
+class HierarchicalProbUNet(BaseModule):
+    """Train an SMP spatial latent hierarchy with GECO (default) or ELBO.
+
+    Binary tasks use one sigmoid logit; multiclass tasks use at least two logits.
+    GECO state is checkpointed and updated only in training_step. Persistent
+    multiplier saturation at 1e5 usually means kappa is too low for the data.
+    """
+
+    valid_tasks: ClassVar[list[str]] = ["multiclass", "binary"]
+    valid_loss_types: ClassVar[list[str]] = ["geco", "elbo"]
+    pred_dir_name = "preds"
+    log_lagmul: Tensor
+    ma_rec_loss: Tensor
+
+    def __init__(
+        self,
+        model: nn.Module,
+        num_classes: int,
+        loss_type: str = "geco",
+        kappa: float = 0.05,
+        decay: float = 0.99,
+        rate: float = 1e-2,
+        lagrange_init: float = 1.0,
+        beta: float = 1.0,
+        top_k_percentage: float | None = 0.02,
+        deterministic_top_k: bool = False,
+        num_samples: int = 16,
+        task: str = "multiclass",
+        freeze_backbone: bool = False,
+        freeze_decoder: bool = False,
+        optimizer: OptimizerCallable = torch.optim.Adam,
+        lr_scheduler: LRSchedulerCallable | None = None,
+        save_preds: bool = False,
+    ) -> None:
+        """Initialize the model, segmentation metrics and checkpointed GECO state.
+
+        Args:
+            model: Hierarchical model exposing sample and reconstruct.
+            num_classes: Logit channels, explicitly specified without introspection.
+            loss_type: "geco" or "elbo".
+            kappa: Target CE per selected valid pixel.
+            decay: Reconstruction exponential moving-average decay.
+            rate: Multiplicative GECO update rate in log space.
+            lagrange_init: Positive initial Lagrange multiplier.
+            beta: KL weight for ELBO.
+            top_k_percentage: Hard-pixel fraction or None to use all pixels.
+            deterministic_top_k: Disable Gumbel perturbation in pixel selection.
+            num_samples: Prior samples per prediction.
+            task: "multiclass" or single-logit "binary".
+            freeze_backbone: Freeze both SMP encoders.
+            freeze_decoder: Freeze the deterministic stitching tail and head.
+            optimizer: Optimizer factory for network weights.
+            lr_scheduler: Optional scheduler factory (epoch interval).
+            save_preds: Save test predictions as HDF5 files.
+        """
+        super().__init__()
+        if not callable(getattr(model, "sample", None)) or not callable(
+            getattr(model, "reconstruct", None)
+        ):
+            raise TypeError("model must expose sample() and reconstruct().")
+        if task not in self.valid_tasks or loss_type not in self.valid_loss_types:
+            raise ValueError("Unsupported task or loss_type.")
+        if (task == "binary" and num_classes != 1) or (
+            task == "multiclass" and num_classes < 2
+        ):
+            raise ValueError(
+                "binary requires num_classes=1; multiclass requires at least 2."
+            )
+        if not (
+            0 <= decay < 1
+            and rate >= 0
+            and kappa >= 0
+            and beta >= 0
+            and 0 < lagrange_init <= 1e5
+            and num_samples >= 1
+        ):
+            raise ValueError("Invalid GECO, beta or sampling hyperparameters.")
+        if top_k_percentage is not None and not 0 < top_k_percentage <= 1:
+            raise ValueError("top_k_percentage must be in (0, 1] or None.")
+        if getattr(model, "classes", num_classes) != num_classes:
+            raise ValueError("num_classes must match the model's logit channels.")
+        self.save_hyperparameters(ignore=["model", "optimizer", "lr_scheduler"])
+        self.model = cast(HierarchicalProbUNetModel, model)
+        self.num_classes, self.task = num_classes, task
+        self.loss_type, self.kappa, self.decay, self.rate = (
+            loss_type,
+            kappa,
+            decay,
+            rate,
+        )
+        self.beta, self.num_samples = beta, num_samples
+        self.top_k_percentage, self.deterministic_top_k = (
+            top_k_percentage,
+            deterministic_top_k,
+        )
+        self.freeze_backbone, self.freeze_decoder = freeze_backbone, freeze_decoder
+        self.optimizer, self.lr_scheduler, self.save_preds = (
+            optimizer,
+            lr_scheduler,
+            save_preds,
+        )
+        self.register_buffer("log_lagmul", torch.tensor(math.log(lagrange_init)))
+        self.register_buffer("ma_rec_loss", torch.tensor(float("nan")))
+        self.train_metrics = default_segmentation_metrics(
+            prefix="train", num_classes=num_classes, task=task
+        )
+        self.val_metrics = default_segmentation_metrics(
+            prefix="val", num_classes=num_classes, task=task
+        )
+        self.test_metrics = default_segmentation_metrics(
+            prefix="test", num_classes=num_classes, task=task
+        )
+        self.freeze_model()
+
+    def freeze_model(self) -> None:
+        """Freeze both backbones or only the deterministic stitching tail and head."""
+        if self.freeze_backbone:
+            self.model.prior_encoder.requires_grad_(False)
+            self.model.posterior_encoder.requires_grad_(False)
+        if self.freeze_decoder:
+            n = len(self.model.latent_dims)
+            self.model.prior_decoder.blocks[n:].requires_grad_(False)
+            self.model.segmentation_head.requires_grad_(False)
+
+    def _targets(self, target: Tensor) -> Tensor:
+        if target.ndim == 4 and target.shape[1] == self.num_classes:
+            return target.float()
+        if target.ndim == 4 and target.shape[1] == 1:
+            target = target.squeeze(1)
+        if self.task == "binary":
+            return target.unsqueeze(1).float()
+        return F.one_hot(target.long(), self.num_classes).movedim(-1, 1).float()
+
+    def _geco_constraint(
+        self, rec: Tensor, valid_pixels: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        # Global statistics keep GECO buffers identical across DDP ranks.
+        stats = torch.stack([rec.detach(), valid_pixels.detach()])
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            torch.distributed.all_reduce(stats)
+            stats /= torch.distributed.get_world_size()
+        ma = torch.where(
+            self.ma_rec_loss.isnan(),
+            stats[0],
+            self.decay * self.ma_rec_loss + (1 - self.decay) * stats[0],
+        )
+        # Forward uses the EMA; backward retains the full current CE gradient.
+        constraint = rec + (ma - rec).detach() - self.kappa * stats[1]
+        return constraint, ma
+
+    @torch.no_grad()
+    def _update_geco(self, constraint: Tensor, ma: Tensor) -> None:
+        self.ma_rec_loss.copy_(ma)
+        self.log_lagmul.add_(self.rate * constraint.detach()).clamp_(
+            math.log(1e-5), math.log(1e5)
+        )
+
+    def compute_loss(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Return loss, per-scale KL nats and [B, C, H, W] reconstruction logits."""
+        logits, q, p = self.reconstruct(
+            batch[self.input_key], self._targets(batch[self.target_key])
+        )
+        rec = hierarchical_ce_loss(
+            logits,
+            self._targets(batch[self.target_key]),
+            self.top_k_percentage,
+            self.deterministic_top_k,
+        )
+        out = {
+            f"kl_{i}": kl_divergence(qi, pi).flatten(1).sum(1).mean()
+            for i, (qi, pi) in enumerate(zip(q, p, strict=True))
+        }
+        kl_sum = torch.stack(list(out.values())).sum()
+        out.update(
+            rec_loss_sum=rec["sum"],
+            rec_loss_mean=rec["mean"],
+            kl_sum=kl_sum,
+            reconstruction=logits,
+        )
+        if self.loss_type == "geco":
+            constraint, ma = self._geco_constraint(
+                rec["sum"], rec["mask"].sum(1).mean()
+            )
+            out.update(
+                loss=self.log_lagmul.exp() * constraint + kl_sum,
+                constraint=constraint,
+                ma=ma,
+                lagmul=self.log_lagmul.exp(),
+            )
+        else:
+            out["loss"] = rec["sum"] + self.beta * kl_sum
+        return out
+
+    def _step(self, batch: dict[str, Tensor], stage: str) -> dict[str, Tensor]:
+        out = self.compute_loss(batch)
+        self.log_dict(
+            {
+                f"{stage}_{k}": v
+                for k, v in out.items()
+                if k not in {"reconstruction", "ma"}
+            },
+            batch_size=batch[self.input_key].shape[0],
+        )
+        target = self._targets(batch[self.target_key])
+        target = target.squeeze(1).long() if self.task == "binary" else target.argmax(1)
+        pred = out["reconstruction"].detach()
+        if self.task == "binary":
+            pred = pred.squeeze(1).sigmoid()
+        getattr(self, f"{stage}_metrics")(pred, target)
+        return out
+
+    def training_step(self, batch: dict[str, Tensor], batch_idx: int) -> Tensor:
+        """Optimize reconstruction and KL, updating GECO state once per batch."""
+        out = self._step(batch, "train")
+        if self.loss_type == "geco" and self.training:
+            self._update_geco(out["constraint"], out["ma"])
+        return out["loss"]
+
+    def validation_step(self, batch: dict[str, Tensor], batch_idx: int) -> Tensor:
+        """Score posterior reconstructions without updating GECO state."""
+        return self._step(batch, "val")["loss"]
+
+    def on_train_epoch_end(self) -> None:
+        """Log and reset training metrics."""
+        self.log_dict(self.train_metrics.compute())
+        self.train_metrics.reset()
+
+    def on_validation_epoch_end(self) -> None:
+        """Log and reset validation metrics."""
+        self.log_dict(self.val_metrics.compute())
+        self.val_metrics.reset()
+
+    def sample(
+        self,
+        img: Tensor,
+        mean: bool | Sequence[bool] = False,
+        z_q: Sequence[Tensor] | None = None,
+    ) -> Tensor:
+        """Sample prior logits [B, C, H, W] without storing batch state."""
+        return self.model.sample(img, mean, z_q)
+
+    def reconstruct(
+        self, img: Tensor, seg_one_hot: Tensor, mean: bool | Sequence[bool] = False
+    ) -> tuple[Tensor, list[Independent], list[Independent]]:
+        """Return posterior logits and q/p distributions for NCHW images/targets."""
+        return self.model.reconstruct(img, seg_one_hot, mean)
+
+    def forward(self, X: Tensor) -> Tensor:
+        """Sample one prior segmentation as [B, C, H, W] logits."""
+        return self.sample(X)
+
+    def predict_step(
+        self, X: Tensor, batch_idx: int = 0, dataloader_idx: int = 0
+    ) -> dict[str, Tensor]:
+        """Return probabilities, entropy and logits [B, C, H, W, num_samples]."""
+        samples = torch.stack([self.sample(X) for _ in range(self.num_samples)], dim=-1)
+        return process_segmentation_prediction(samples, task=self.task)
+
+    def test_step(self, batch: dict[str, Tensor], batch_idx: int) -> dict[str, Tensor]:
+        """Evaluate prior predictions and include targets and auxiliary data."""
+        out = self.predict_step(batch[self.input_key])
+        target = self._targets(batch[self.target_key])
+        target = target.squeeze(1).long() if self.task == "binary" else target.argmax(1)
+        pred = out["pred"].squeeze(1) if self.task == "binary" else out["pred"]
+        self.test_metrics(pred, target)
+        out[self.target_key] = batch[self.target_key]
+        return self.add_aux_data_to_dict(out, batch)
+
+    def on_test_start(self) -> None:
+        """Create the prediction directory when saving is requested."""
+        self.pred_dir = os.path.join(self.trainer.default_root_dir, self.pred_dir_name)
+        if self.save_preds:
+            os.makedirs(self.pred_dir, exist_ok=True)
+
+    def on_test_epoch_end(self) -> None:
+        """Log and reset prior prediction metrics."""
+        self.log_dict(self.test_metrics.compute())
+        self.test_metrics.reset()
+
+    def on_test_batch_end(
+        self, outputs: STEP_OUTPUT, batch: Any, batch_idx: int, dataloader_idx: int = 0
+    ) -> None:
+        """Save test predictions when enabled."""
+        if self.save_preds:
+            save_image_predictions(outputs, batch_idx, self.pred_dir)
+
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        """Configure the network optimizer, keeping the GECO multiplier separate."""
+        optimizer = self.optimizer(p for p in self.parameters() if p.requires_grad)
+        if self.lr_scheduler is not None:
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {
+                    "scheduler": self.lr_scheduler(optimizer),
+                    "monitor": "val_loss",
+                },
+            }
+        return {"optimizer": optimizer}

--- a/tests/configs/image_segmentation/hierarchical_prob_unet.yaml
+++ b/tests/configs/image_segmentation/hierarchical_prob_unet.yaml
@@ -1,0 +1,20 @@
+uq_method:
+  _target_: lightning_uq_box.uq_methods.HierarchicalProbUNet
+  model:
+    _target_: lightning_uq_box.models.HierarchicalProbUNet
+    encoder_name: resnet18
+    encoder_weights: null
+    classes: 4
+    in_channels: 3
+    decoder_channels: [32, 16, 8, 4, 2]
+    latent_dims: [1, 1]
+    blocks_per_level: 1
+  num_classes: 4
+  num_samples: 2
+  optimizer:
+    _target_: torch.optim.Adam
+    _partial_: true
+    lr: 0.0001
+  lr_scheduler:
+    _target_: torch.optim.lr_scheduler.ConstantLR
+    _partial_: true

--- a/tests/eval_utils/test_segmentation_distribution.py
+++ b/tests/eval_utils/test_segmentation_distribution.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+import pytest
+import torch
+
+from lightning_uq_box.eval_utils import (
+    generalized_energy_distance,
+    hungarian_matched_iou,
+    iou_with_empty_convention,
+    reconstruction_iou,
+)
+
+
+def test_empty_and_disjoint() -> None:
+    empty = torch.zeros(2, 3, 3, dtype=torch.long)
+    full = torch.ones_like(empty)
+    torch.testing.assert_close(
+        iou_with_empty_convention(empty, empty, 2), torch.ones(2)
+    )
+    torch.testing.assert_close(reconstruction_iou(empty, full, 2), torch.zeros(2))
+
+
+def test_analytic_ged_and_balancing() -> None:
+    samples = torch.tensor([[[[0]], [[1]]]])
+    graders = samples.repeat(1, 2, 1, 1)
+    result = generalized_energy_distance(samples, graders, 2)
+    assert result["ged"].item() == 0
+    assert (
+        result["d_ss"].item() == result["d_sy"].item() == result["d_yy"].item() == 0.5
+    )
+    assert hungarian_matched_iou(samples, graders, 2).item() == 1
+    assert hungarian_matched_iou(samples[:, :1], samples[:, 1:], 2).item() == 0
+    assert (
+        generalized_energy_distance(samples[:, :1], samples[:, 1:], 2)["ged"].item()
+        == 2
+    )
+    # Two vs three maps: equal weighting requires repeating BOTH to six.
+    three = torch.tensor([[[[0]], [[0]], [[1]]]])
+    torch.testing.assert_close(
+        hungarian_matched_iou(samples, three, 2), torch.tensor([5 / 6])
+    )
+
+
+def test_multiclass_and_invalid_probabilities() -> None:
+    pred = torch.tensor([[[1, 1], [2, 0]]])
+    target = torch.tensor([[[1, 2], [2, 0]]])
+    torch.testing.assert_close(
+        iou_with_empty_convention(pred, target, 3), torch.tensor([0.5])
+    )
+    with pytest.raises(ValueError, match="hard label"):
+        generalized_energy_distance(pred[:, None].float(), target[:, None], 3)

--- a/tests/models/test_hierarchical_prob_unet.py
+++ b/tests/models/test_hierarchical_prob_unet.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+import pytest
+import torch
+from torch.distributions import kl_divergence
+
+from lightning_uq_box.models import (
+    HierarchicalProbUNet,
+    HierarchicalUnetDecoder,
+    PreActResBlock,
+)
+
+
+@pytest.fixture
+def model() -> HierarchicalProbUNet:
+    torch.manual_seed(17)
+    return HierarchicalProbUNet(
+        encoder_name="resnet18",
+        encoder_weights=None,
+        decoder_channels=(16, 8, 4, 4, 2),
+        latent_dims=(2, 2),
+        decoder_use_norm=False,
+    )
+
+
+@pytest.mark.parametrize("latent_dims", [(1, 1, 1, 1), (2, 2)])
+@pytest.mark.parametrize("encoder", ["resnet18", "tu-mobilenetv3_small_100"])
+def test_scales_and_encoder_swap(latent_dims: tuple[int, ...], encoder: str) -> None:
+    model = HierarchicalProbUNet(
+        encoder_name=encoder,
+        encoder_weights=None,
+        in_channels=1,
+        latent_dims=latent_dims,
+        decoder_channels=(16, 8, 4, 4, 2),
+    ).eval()
+    x = torch.randn(2, 1, 64, 64)
+    with torch.no_grad():
+        p = model.prior_decoder(model.prior_encoder(x))
+        forced = model.prior_decoder(model.prior_encoder(x), z_q=p.used_latents)
+        logits, q, prior = model.reconstruct(x, torch.randn(2, 2, 64, 64))
+    assert logits.shape == (2, 2, 64, 64)
+    for i, (dim, dist, z) in enumerate(
+        zip(latent_dims, p.distributions, p.used_latents, strict=True)
+    ):
+        assert dist.event_shape == (dim,)
+        assert dist.batch_shape == (2, 2 * 2**i, 2 * 2**i)
+        assert z.shape == (2, dim, 2 * 2**i, 2 * 2**i)
+        torch.testing.assert_close(z, forced.used_latents[i], rtol=0, atol=0)
+        assert (kl_divergence(q[i], prior[i]) >= 0).all()
+        channels = list(model.prior_encoder.out_channels[1:])[::-1]
+        base = channels[0] if i == 0 else (16, 8, 4, 4, 2)[i - 1]
+        conv1 = model.prior_decoder.blocks[i].conv1
+        assert isinstance(conv1, torch.nn.Sequential)
+        conv = conv1[0]
+        assert isinstance(conv, torch.nn.Conv2d)
+        assert conv.in_channels == base + channels[i + 1] + dim
+
+
+def test_matching_conditionals_have_zero_kl() -> None:
+    q_decoder = HierarchicalUnetDecoder(
+        encoder_channels=(3, 4, 8, 16),
+        decoder_channels=(8, 4, 2),
+        n_blocks=3,
+        latent_dims=(2, 2),
+        use_norm=False,
+    )
+    p_decoder = HierarchicalUnetDecoder(
+        encoder_channels=(3, 4, 8, 16),
+        decoder_channels=(8, 4, 2),
+        n_blocks=3,
+        latent_dims=(2, 2),
+        use_norm=False,
+    )
+    p_decoder.load_state_dict(q_decoder.state_dict())
+    features = [torch.randn(2, c, s, s) for c, s in [(3, 32), (4, 16), (8, 8), (16, 4)]]
+    q = q_decoder(features)
+    p = p_decoder(features, z_q=q.used_latents)
+    for qi, pi, zq, zp in zip(
+        q.distributions, p.distributions, q.used_latents, p.used_latents, strict=True
+    ):
+        assert kl_divergence(qi, pi).abs().max() < 1e-5
+        assert zq is zp
+    # A free prior draw must change the finer conditional, guarding the test itself.
+    free = p_decoder(features)
+    assert not torch.equal(free.distributions[1].mean, q.distributions[1].mean)
+
+
+def test_reconstruction_reparameterizes_posterior(model: HierarchicalProbUNet) -> None:
+    x = torch.randn(2, 3, 64, 64)
+    logits, _, _ = model.reconstruct(x, torch.randn(2, 2, 64, 64))
+    logits.square().mean().backward()
+    # Prior gradients alone would also pass if the posterior used sample().
+    for encoder in [model.prior_encoder, model.posterior_encoder]:
+        grad = next(encoder.parameters()).grad
+        assert grad is not None and torch.isfinite(grad).all() and grad.abs().sum() > 0
+    for head in model.posterior_decoder.latent_heads:
+        assert isinstance(head, torch.nn.Conv2d)
+        assert head.weight.grad is not None
+        assert head.weight.grad.abs().sum() > 0
+
+
+def test_all_trainable_parameters_used(model: HierarchicalProbUNet) -> None:
+    logits, q, p = model.reconstruct(
+        torch.randn(2, 3, 64, 64), torch.randn(2, 2, 64, 64)
+    )
+    (
+        logits.square().mean()
+        + sum(kl_divergence(qi, pi).mean() for qi, pi in zip(q, p, strict=True))
+    ).backward()
+    assert not [
+        name
+        for name, param in model.named_parameters()
+        if param.requires_grad and param.grad is None
+    ]
+
+
+def test_stateless_means_and_intervention(model: HierarchicalProbUNet) -> None:
+    model.eval()
+    x = torch.randn(2, 3, 64, 64)
+    with torch.no_grad():
+        expected = model.sample(x, mean=True)
+        model.sample(torch.randn_like(x))
+        torch.testing.assert_close(expected, model.sample(x, mean=[True, True]))
+        assert not torch.equal(expected, model.sample(x, mean=[True, False]))
+        prior = model.prior_decoder(model.prior_encoder(x), mean=True)
+        torch.testing.assert_close(expected, model.sample(x, z_q=prior.used_latents))
+    with pytest.raises(ValueError, match="per scale"):
+        model.sample(x, mean=[True])
+    with pytest.raises(ValueError, match="shape"):
+        model.sample(x, z_q=[torch.zeros(1), torch.zeros(1)])
+
+
+def test_invalid_hierarchy() -> None:
+    with pytest.raises(ValueError, match="stitching"):
+        HierarchicalProbUNet(
+            encoder_depth=2,
+            encoder_weights=None,
+            decoder_channels=(8, 4),
+            latent_dims=(1, 1),
+        )
+
+
+def test_residual_projection() -> None:
+    block = PreActResBlock(3, 5, down_channels=2)
+    assert block(torch.randn(2, 3, 8, 8)).shape == (2, 5, 8, 8)
+    assert not any(isinstance(m, torch.nn.BatchNorm2d) for m in block.modules())
+
+
+def test_extreme_scales_remain_finite_under_autocast(
+    model: HierarchicalProbUNet,
+) -> None:
+    model.eval()
+    with torch.no_grad():
+        for decoder in [model.prior_decoder, model.posterior_decoder]:
+            for head in decoder.latent_heads:
+                assert isinstance(head, torch.nn.Conv2d)
+                assert head.bias is not None
+                head.weight.zero_()
+                head.bias[:2].zero_()
+                head.bias[2:].fill_(1000)
+        with torch.autocast("cpu", dtype=torch.bfloat16):
+            logits, q, p = model.reconstruct(
+                torch.randn(2, 3, 64, 64), torch.randn(2, 2, 64, 64)
+            )
+    assert torch.isfinite(logits).all()
+    for qi, pi in zip(q, p, strict=True):
+        assert qi.mean.dtype == torch.float32
+        assert torch.isfinite(kl_divergence(qi, pi)).all()

--- a/tests/uq_methods/test_hierarchical_prob_unet.py
+++ b/tests/uq_methods/test_hierarchical_prob_unet.py
@@ -1,0 +1,144 @@
+# Copyright (c) 2023 lightning-uq-box. All rights reserved.
+# Licensed under the Apache License 2.0.
+
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from lightning_uq_box.models import HierarchicalProbUNet as Model
+from lightning_uq_box.uq_methods import HierarchicalProbUNet
+from lightning_uq_box.uq_methods.hierarchical_prob_unet import hierarchical_ce_loss
+
+
+def make_method(**kwargs) -> HierarchicalProbUNet:
+    classes = 1 if kwargs.get("task") == "binary" else 2
+    return HierarchicalProbUNet(
+        Model(
+            encoder_name="resnet18",
+            encoder_depth=3,
+            encoder_weights=None,
+            decoder_channels=(8, 4, 2),
+            latent_dims=(1, 1),
+            classes=classes,
+        ),
+        num_classes=classes,
+        num_samples=2,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("loss_type", ["geco", "elbo"])
+@pytest.mark.parametrize("task", ["multiclass", "binary"])
+def test_loss_prediction_and_gradients(loss_type: str, task: str) -> None:
+    method = make_method(loss_type=loss_type, task=task)
+    batch = {
+        "input": torch.randn(2, 3, 32, 32),
+        "target": torch.randint(2, (2, 32, 32)),
+    }
+    loss = method.compute_loss(batch)
+    assert torch.isfinite(loss["loss"]) and loss["loss"] != 0
+    assert {"kl_0", "kl_1", "kl_sum"} <= loss.keys()
+    loss["loss"].backward()
+    method.eval()
+    with torch.no_grad():
+        out = method.predict_step(batch["input"])
+    assert out["logits"].shape == (2, method.num_classes, 32, 32, 2)
+    assert torch.isfinite(out["pred_uct"]).all()
+    assert method.ma_rec_loss.isnan()  # compute_loss has no mutation
+
+
+def test_geco_direction_gradient_and_checkpoint(tmp_path: Path) -> None:
+    method = make_method(decay=0.9, kappa=0.5, rate=0.01)
+    rec = torch.tensor(10.0, requires_grad=True)
+    constraint, ma = method._geco_constraint(rec, torch.tensor(2.0))
+    constraint.backward()
+    torch.testing.assert_close(rec.grad, torch.tensor(1.0))
+    method._update_geco(constraint, ma)
+    assert method.log_lagmul > 0
+    previous = method.log_lagmul.clone()
+    method._update_geco(torch.tensor(-2.0), torch.tensor(3.0))
+    assert method.log_lagmul < previous
+    rec2 = torch.tensor(1.0, requires_grad=True)
+    constraint2, ma2 = method._geco_constraint(rec2, torch.tensor(2.0))
+    torch.testing.assert_close(ma2, torch.tensor(2.8))
+    constraint2.backward()
+    torch.testing.assert_close(rec2.grad, torch.tensor(1.0))
+    path = tmp_path / "state.pt"
+    torch.save(method.state_dict(), path)
+    restored = make_method()
+    restored.load_state_dict(torch.load(path, weights_only=True))
+    torch.testing.assert_close(restored.log_lagmul, method.log_lagmul)
+    torch.testing.assert_close(restored.ma_rec_loss, method.ma_rec_loss)
+    assert "log_lagmul" not in dict(method.named_parameters())
+
+
+@pytest.mark.parametrize(
+    "backbone,decoder", [(True, False), (False, True), (True, True)]
+)
+def test_freezing(backbone: bool, decoder: bool) -> None:
+    method = make_method(freeze_backbone=backbone, freeze_decoder=decoder)
+    for name, param in method.model.named_parameters():
+        frozen = (backbone and "encoder" in name) or (
+            decoder
+            and (name.startswith(("segmentation_head", "prior_decoder.blocks.2")))
+        )
+        assert param.requires_grad != frozen, name
+
+
+def test_soft_ce_and_batch_topk() -> None:
+    logits = torch.tensor(
+        [[[[0.0, 0.0]], [[0.0, 0.0]]], [[[0.0, 0.0]], [[2.0, 3.0]]]], requires_grad=True
+    )
+    target = torch.zeros_like(logits)
+    target[:, 0] = 1
+    all_pixels = hierarchical_ce_loss(logits, target, None)
+    expected = -(target * logits.log_softmax(1)).sum(1)
+    torch.testing.assert_close(all_pixels["sum"], expected.sum() / 2)
+    torch.testing.assert_close(all_pixels["mean"], expected.mean())
+    topk = hierarchical_ce_loss(logits, target, 0.5, True)
+    torch.testing.assert_close(topk["mask"], torch.tensor([[0.0, 0.0], [1.0, 1.0]]))
+    topk["sum"].backward()
+    assert logits.grad is not None and logits.grad[0].count_nonzero() == 0
+    soft = torch.full_like(target, 0.5)
+    torch.testing.assert_close(
+        hierarchical_ce_loss(logits, soft, None)["sum"],
+        F.cross_entropy(logits, soft, reduction="none").sum() / 2,
+    )
+
+
+def test_masking_and_stochastic_selection() -> None:
+    logits = torch.zeros(2, 2, 4, 4, requires_grad=True)
+    target = torch.full_like(logits, 0.5)
+    valid = torch.zeros(2, 4, 4)
+    valid[:, :2] = 1
+    masks = []
+    for seed in [0, 1]:
+        torch.manual_seed(seed)
+        result = hierarchical_ce_loss(logits, target, 0.25, mask=valid)
+        assert result["mask"].sum() == 8
+        assert (result["mask"].reshape_as(valid) <= valid).all()
+        masks.append(result["mask"])
+    assert not torch.equal(*masks)
+    empty = hierarchical_ce_loss(logits, target, mask=torch.zeros_like(valid))
+    assert empty["sum"] == 0 and empty["mean"] == 0
+    empty["sum"].backward()
+    assert logits.grad is not None and logits.grad.count_nonzero() == 0
+
+
+def test_geco_updates_only_training_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    method = make_method()
+    monkeypatch.setattr(method, "log_dict", lambda *args, **kwargs: None)
+    batch = {
+        "input": torch.randn(2, 3, 32, 32),
+        "target": torch.randint(2, (2, 32, 32)),
+    }
+    method.training_step(batch, 0).backward()
+    assert method.ma_rec_loss.isfinite()
+    saved = method.log_lagmul.clone(), method.ma_rec_loss.clone()
+    method.eval()
+    with torch.no_grad():
+        method.validation_step(batch, 0)
+    torch.testing.assert_close(saved[0], method.log_lagmul)
+    torch.testing.assert_close(saved[1], method.ma_rec_loss)

--- a/tests/uq_methods/test_image_segmentation.py
+++ b/tests/uq_methods/test_image_segmentation.py
@@ -22,6 +22,7 @@ from lightning_uq_box.uq_methods import DeepEnsembleSegmentation
 seed_everything(0)
 
 model_config_paths = [
+    "tests/configs/image_segmentation/hierarchical_prob_unet.yaml",
     "tests/configs/image_segmentation/base.yaml",
     "tests/configs/image_segmentation/bnn_vi_elbo.yaml",
     "tests/configs/image_segmentation/bnn_vi_elbo_part_stoch.yaml",


### PR DESCRIPTION
Add `HierarchicalProbUNet`, an independent SMP-backed segmentation method: spatial autoregressive latents, teacher-forced prior/posterior KL, reparameterized reconstruction, GECO by default and fixed-beta ELBO as an alternative. It adds hard-pixel mining, checkpointed GECO state, freezing, prior prediction, distribution metrics and a runnable latent-intervention tutorial.

The posterior stops at its last distribution to avoid unused trainable weights. Pre-head residual refinements are controlled by `blocks_per_level`/`convs_per_block`; SMP blocks handle skip fusion. Gaussian log scales are bounded to [-10, 10] in float32. GECO uses a straight-through reconstruction EMA and a buffer update independent of the optimizer. The paper's eight-scale backbone is not shipped.

Validation: full locked-environment CPU suite **644 passed, 1 slow test deselected**, 96% coverage; Ruff and ty passed. Sphinx HTML builds (pre-existing documentation warnings only). All tutorial code cells executed successfully. Tests cover teacher-forced conditional KL, gradient flow into both encoders, SMP encoder swapping, mixed-precision stability, GECO direction/checkpoints, freezing and the Lightning fit/test/save path.

Both LIDC models were trained to **2,000 steps** with resnet34/ImageNet, grayscale 128×128 crops, batch size 32, Adam at 1e-4 and weight decay 1e-5. The runs resume their respective 200-step smoke checkpoints; the dataloader does not restore mid-epoch position, so these are development comparisons rather than exact uninterrupted reproductions. Flat ProbUNet uses its existing beta=10 ELBO; the hierarchy uses GECO (kappa=0.05, top-k=2%) and 54,227,730 parameters, versus 27,168,636 for the flat model. The same backbone therefore does not imply matched total capacity. Both continuation runs use gradient clipping at 1.0. LR milestones are beyond this short run.

Final evaluation covers **all 1,980 staged test crops**, reconstruction against **all four graders**, and **16 prior samples per crop**. Metrics use foreground IoU with empty-vs-empty=1 and image-weighted aggregation.

| Metric | Flat, 2,000 steps | Hierarchical, 2,000 steps | Paper flat → hierarchical |
|---|---:|---:|---:|
| Reconstruction IoU | 0.4373 | 0.9670 | 0.75 → 0.97 |
| GED² ↓ | 0.5352 | 0.4175 | 0.32 → 0.27 |
| Hungarian IoU ↑ | 0.4809 | 0.3616 | 0.50 → 0.53 |
| Diversity d_ss | 0.1668 | 0.6156 | — |

Paper values are from [Kohl et al., Table 1 and §3.2](https://arxiv.org/html/1905.13077v1). This is an SMP adaptation with a short training budget and staged crop counts that differ from the original paper. It does **not** establish reproduction of the paper's distributional performance or coarse-to-fine disentanglement. The hierarchy's short run is dominated by the finest latent scale, and prior distribution matching remains an open validation item for longer training.

The hierarchical multiplier ends at 2.44 (it left the 1e5 cap); its moving-average reconstruction sum ends at 17.13. Earlier traces show oscillation around the reconstruction target. The per-scale KL values below are conditional KL evaluated at posterior means, not the sampled training averages:

KL_0 = 0.0003 nats, KL_1 = 0.1228 nats, KL_2 = 1.2035 nats, KL_3 = 51.8967 nats.

The PR contains only the model, wrapper, metrics, tests, exports and documentation. LIDC datasets, experiments and checkpoints remain local.
